### PR TITLE
fix: session_recall reads consolidated decisions archive

### DIFF
--- a/src/context_engine/integration/mcp_server.py
+++ b/src/context_engine/integration/mcp_server.py
@@ -737,6 +737,21 @@ class ContextEngineMCP:
                     seen.add(text)
                     candidates.append(text)
 
+        # Also include the consolidated decisions archive — `prune_old_sessions`
+        # writes decisions into decisions_log.json before deleting the source
+        # session files, so without this step a recall on a long-lived project
+        # would silently forget anything past the most-recent
+        # _SESSION_RECALL_WINDOW files. The CLI's `cce sessions prune`
+        # docstring already promises this works.
+        for decision in self._session_capture._load_consolidated_decisions():
+            text = (
+                f"[decision] {decision.get('decision', '')} — "
+                f"{decision.get('reason', '')}"
+            )
+            if text not in seen:
+                seen.add(text)
+                candidates.append(text)
+
         if not candidates:
             return []
 

--- a/tests/integration/test_memory_loop.py
+++ b/tests/integration/test_memory_loop.py
@@ -197,3 +197,34 @@ def test_prune_consolidates_old_sessions_into_decisions_log(tmp_path):
         f"expected archived decision to be surfaced via get_recent_decisions; "
         f"sample: {surfaced[:5]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_session_recall_searches_decisions_log_archive(project_and_storage):
+    """`session_recall` (i.e. _search_sessions) must include consolidated
+    decisions from decisions_log.json — otherwise pruning silently drops the
+    archive from recall, contradicting the prune CLI's docstring claim that
+    "Decisions remain searchable via session_recall after pruning"."""
+    project_dir, storage_root = project_and_storage
+
+    sessions_dir = storage_root / project_dir.name / "sessions"
+    sessions_dir.mkdir(parents=True)
+
+    # No on-disk per-session files — only the consolidated archive — so we
+    # know the recall hit comes from decisions_log.json, not from a still-
+    # present session file. Use very-distinct text so the substring fallback
+    # would also have a chance if vector recall returned nothing.
+    archive = [
+        {
+            "decision": "Use RS256 JWT signing for service-to-service auth",
+            "reason": "Asymmetric keys mean services can verify without sharing secrets",
+            "timestamp": 1.0,
+        }
+    ]
+    (sessions_dir / "decisions_log.json").write_text(json.dumps(archive))
+
+    server = _build_server(project_dir, storage_root)
+    matches = server._search_sessions("token signing algorithm")
+    assert any("RS256" in m for m in matches), (
+        f"expected archived decision to surface via session_recall; got {matches}"
+    )

--- a/tests/storage/test_delete_batching.py
+++ b/tests/storage/test_delete_batching.py
@@ -1,0 +1,74 @@
+"""Regression: delete_by_files must not trip SQLite's bound-parameter limit.
+
+Pre-batching, vector/fts/graph stores built one IN(...) clause with
+len(file_paths) placeholders. SQLite's SQLITE_MAX_VARIABLE_NUMBER (999 on
+older builds, 32766 on modern) means a project-wide prune touching >999
+files raised `OperationalError: too many SQL variables`.
+
+Each test below ingests a few rows then asks the store to delete by a list
+of >1500 file_paths to force multiple batches through batched_params, and
+asserts the affected rows are gone — exercises the batching helper end-to-
+end so a future regression in any single store would surface here.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest  # noqa: F401  (xdist scheduler hook)
+
+from context_engine.models import (
+    Chunk,
+    ChunkType,
+    EdgeType,
+    GraphEdge,
+    GraphNode,
+    NodeType,
+)
+from context_engine.storage.fts_store import FTSStore
+from context_engine.storage.graph_store import GraphStore
+from context_engine.storage.vector_store import VectorStore
+
+
+def _bulk_paths(n: int = 1500) -> list[str]:
+    return [f"path/file_{i}.py" for i in range(n)]
+
+
+def test_vector_store_delete_handles_oversize_path_list(tmp_path):
+    vs = VectorStore(db_path=str(tmp_path / "vec"))
+    chunk = Chunk(
+        id="c1", content="x", chunk_type=ChunkType.FUNCTION,
+        file_path="real.py", start_line=1, end_line=1, language="python",
+        embedding=[0.1] * 4,
+    )
+    asyncio.run(vs.ingest([chunk]))
+    # Mix in the real file so we know the delete actually executes.
+    paths = _bulk_paths() + ["real.py"]
+    asyncio.run(vs.delete_by_files(paths))
+    assert vs.count() == 0
+
+
+def test_fts_store_delete_handles_oversize_path_list(tmp_path):
+    fts = FTSStore(db_path=str(tmp_path / "fts"))
+    chunk = Chunk(
+        id="c1", content="hello world", chunk_type=ChunkType.FUNCTION,
+        file_path="real.py", start_line=1, end_line=1, language="python",
+    )
+    asyncio.run(fts.ingest([chunk]))
+    paths = _bulk_paths() + ["real.py"]
+    asyncio.run(fts.delete_by_files(paths))
+    results = asyncio.run(fts.search("hello"))
+    assert results == []
+
+
+def test_graph_store_delete_handles_oversize_path_list(tmp_path):
+    gs = GraphStore(db_path=str(tmp_path / "graph"))
+    node = GraphNode(
+        id="n1", node_type=NodeType.FUNCTION, name="f", file_path="real.py"
+    )
+    edge = GraphEdge(source_id="n1", target_id="n1", edge_type=EdgeType.DEFINES)
+    asyncio.run(gs.ingest([node], [edge]))
+
+    paths = _bulk_paths() + ["real.py"]
+    asyncio.run(gs.delete_by_files(paths))
+    nodes = asyncio.run(gs.get_nodes_by_file("real.py"))
+    assert nodes == []


### PR DESCRIPTION
## Summary
- `session_recall` (`_search_sessions`) now also pulls from the consolidated `decisions_log.json` archive, so decisions survive `cce sessions prune` instead of silently disappearing once their source session files are deleted — matching the prune CLI's docstring promise.
- Adds an async integration test that writes only the archive (no per-session files) and asserts the decision surfaces via recall.
- Adds a regression test for `delete_by_files` across vector/fts/graph stores with >1500 paths to guard the SQLite bound-parameter batching helper.

## Test plan
- [ ] `pytest tests/integration/test_memory_loop.py::test_session_recall_searches_decisions_log_archive`
- [ ] `pytest tests/storage/test_delete_batching.py`
- [ ] Full suite: `pytest -n 4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)