### PR TITLE
feat(memory) PR 2/5: capture — 5 lifecycle hooks + HTTP endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Issues = "https://github.com/elara-labs/code-context-engine/issues"
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "pytest-aiohttp>=1.0",
     "pytest-cov>=5.0",
     "pytest-xdist>=3.5",
 ]
@@ -82,5 +83,6 @@ addopts = "-n 4 --dist=loadgroup"
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
+    "pytest-aiohttp>=1.0",
     "pytest-xdist>=3.5",
 ]

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -153,6 +153,27 @@ def _has_cce_hook(hook_list: list, marker: str) -> bool:
     return False
 
 
+def _install_memory_hooks(project_dir: Path) -> None:
+    """Install the 5 lifecycle hooks for memory capture (PR 2).
+
+    Writes ~/.cce/hooks/cce_hook.sh and wires <project>/.claude/settings.json
+    entries for SessionStart, UserPromptSubmit, PostToolUse, Stop, SessionEnd.
+    Idempotent.
+    """
+    from context_engine.memory.hook_installer import (
+        install_hook_script, install_settings,
+    )
+    install_hook_script()
+    summary = install_settings(project_dir)
+    if summary["added"]:
+        _ok(
+            f"Memory hooks installed  "
+            + _dim(f"({len(summary['added'])} hooks: {', '.join(summary['added'])})")
+        )
+    elif summary["skipped"]:
+        _ok("Memory hooks already configured")
+
+
 def _ensure_session_hook(project_dir: Path) -> None:
     """Add Claude Code hooks so CCE status shows on startup."""
     settings_dir = project_dir / ".claude"
@@ -567,9 +588,10 @@ def init(ctx: click.Context) -> None:
     else:
         _ok("MCP server already configured in " + click.style(".mcp.json", fg="cyan"))
 
-    # 5. CLAUDE.md + session hook
+    # 5. CLAUDE.md + session hook + memory lifecycle hooks
     _ensure_claude_md(project_dir)
     _ensure_session_hook(project_dir)
+    _install_memory_hooks(project_dir)
 
     # 6. .gitignore — add CCE per-machine entries
     ensure_gitignore(str(project_dir))
@@ -2054,8 +2076,26 @@ async def _run_serve(config) -> None:
         worker_task = asyncio.create_task(_reindex_worker())
         watcher.start(loop=loop)
 
+    # Memory hook listener — loopback HTTP for the 5 lifecycle hooks. Best
+    # effort: a setup failure here must NOT prevent the MCP server starting
+    # (capture is a non-critical feature; retrieval still works without it).
+    hook_runner = None
+    hook_port = None
+    try:
+        from context_engine.memory.hook_server import start_hook_server
+        hook_runner, hook_port = await start_hook_server(
+            storage_base=storage_base, project_name=project_name,
+        )
+    except Exception as exc:
+        _log.warning("Memory hook server failed to start: %s", exc)
+
     watcher_label = " · live watcher active" if watcher else ""
-    print(f"CCE ready · {project_name} · {chunk_count} chunks indexed{watcher_label}", file=sys.stderr)
+    hook_label = f" · memory hooks :{hook_port}" if hook_port else ""
+    print(
+        f"CCE ready · {project_name} · {chunk_count} chunks indexed"
+        f"{watcher_label}{hook_label}",
+        file=sys.stderr,
+    )
 
     try:
         await mcp.run_stdio()
@@ -2068,3 +2108,8 @@ async def _run_serve(config) -> None:
                 await worker_task
             except asyncio.CancelledError:
                 pass
+        if hook_runner is not None:
+            try:
+                await hook_runner.cleanup()
+            except Exception:
+                _log.warning("hook_runner cleanup failed", exc_info=True)

--- a/src/context_engine/memory/hook_installer.py
+++ b/src/context_engine/memory/hook_installer.py
@@ -1,0 +1,156 @@
+"""Install/uninstall the 5 Claude Code lifecycle hooks for memory capture.
+
+Two pieces of state to manage:
+
+1. The shell script `cce_hook.sh` lives at `~/.cce/hooks/cce_hook.sh`. It's
+   tiny (~20 lines) and reads stdin → POSTs to the local memory hook server.
+
+2. The project-level `<project>/.claude/settings.json` gets entries under
+   `hooks.<HookName>` pointing to the script. Existing CCE entries (and any
+   user-added entries) are preserved.
+
+Install is idempotent: re-running adds nothing new if the entries already
+exist. Uninstall removes only the entries we added (matched by command
+substring).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import stat
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+HOOK_SCRIPT_NAME = "cce_hook.sh"
+HOOK_DIR = Path.home() / ".cce" / "hooks"
+HOOK_PATH = HOOK_DIR / HOOK_SCRIPT_NAME
+
+# Marker substring used to identify hooks we own — survives subsequent
+# format/path tweaks as long as the script name stays.
+HOOK_MARKER = HOOK_SCRIPT_NAME
+
+LIFECYCLE_HOOKS = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PostToolUse",
+    "Stop",
+    "SessionEnd",
+]
+
+_HOOK_SCRIPT_BODY = """#!/bin/sh
+# CCE memory hook — installed by `cce init`. Forwards Claude Code hook
+# payloads (JSON on stdin) to the local memory capture server.
+#
+# Failure is silent — capture is best-effort and must never block the
+# user's flow. The hook name is passed as $1 (first argument).
+set -u
+
+HOOK_NAME="${1:-unknown}"
+PORT_FILE="${HOME}/.cce/projects/$(basename "${PWD}")/serve.port"
+[ -r "${PORT_FILE}" ] || exit 0
+PORT="$(cat "${PORT_FILE}" 2>/dev/null)"
+[ -n "${PORT}" ] || exit 0
+
+curl -sf -m 1 -X POST -H "Content-Type: application/json" \\
+    --data-binary @- "http://127.0.0.1:${PORT}/hooks/${HOOK_NAME}" \\
+    >/dev/null 2>&1 || true
+exit 0
+"""
+
+
+def install_hook_script(target: Path = HOOK_PATH) -> bool:
+    """Write `cce_hook.sh` to ~/.cce/hooks/. Returns True if created/updated."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existing = target.read_text() if target.exists() else None
+    if existing == _HOOK_SCRIPT_BODY:
+        return False
+    target.write_text(_HOOK_SCRIPT_BODY)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return True
+
+
+def install_settings(project_dir: Path) -> dict:
+    """Wire all 5 lifecycle hooks into <project>/.claude/settings.json.
+
+    Idempotent. Preserves any existing user hooks. Returns a summary dict
+    with `added` (hook names we wrote) and `skipped` (hook names already
+    present).
+    """
+    settings_dir = project_dir / ".claude"
+    settings_path = settings_dir / "settings.json"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+
+    data: dict = {}
+    if settings_path.exists():
+        try:
+            data = json.loads(settings_path.read_text() or "{}")
+            if not isinstance(data, dict):
+                data = {}
+        except json.JSONDecodeError:
+            log.warning("Existing settings.json is invalid JSON; rewriting.")
+            data = {}
+
+    hooks = data.setdefault("hooks", {})
+    added: list[str] = []
+    skipped: list[str] = []
+
+    for hook_name in LIFECYCLE_HOOKS:
+        bucket = hooks.setdefault(hook_name, [])
+        if _has_cce_hook(bucket):
+            skipped.append(hook_name)
+            continue
+        bucket.append({
+            "matcher": "",
+            "hooks": [{
+                "type": "command",
+                "command": f"{HOOK_PATH} {hook_name}",
+            }],
+        })
+        added.append(hook_name)
+
+    settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    return {"added": added, "skipped": skipped, "settings_path": str(settings_path)}
+
+
+def uninstall_settings(project_dir: Path) -> dict:
+    """Remove our 5 hook entries from settings.json. Idempotent."""
+    settings_path = project_dir / ".claude" / "settings.json"
+    if not settings_path.exists():
+        return {"removed": [], "settings_path": str(settings_path)}
+    try:
+        data = json.loads(settings_path.read_text() or "{}")
+    except json.JSONDecodeError:
+        return {"removed": [], "settings_path": str(settings_path)}
+    if not isinstance(data, dict):
+        return {"removed": [], "settings_path": str(settings_path)}
+
+    hooks = data.get("hooks") or {}
+    removed: list[str] = []
+    for hook_name in LIFECYCLE_HOOKS:
+        bucket = hooks.get(hook_name)
+        if not bucket:
+            continue
+        kept = [entry for entry in bucket if not _has_cce_hook([entry])]
+        if len(kept) != len(bucket):
+            removed.append(hook_name)
+        if kept:
+            hooks[hook_name] = kept
+        else:
+            del hooks[hook_name]
+
+    if removed:
+        if not hooks:
+            data.pop("hooks", None)
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    return {"removed": removed, "settings_path": str(settings_path)}
+
+
+def _has_cce_hook(bucket: list) -> bool:
+    """True if any entry in the bucket runs our hook script."""
+    for entry in bucket:
+        for h in entry.get("hooks", []) or []:
+            cmd = h.get("command", "") or ""
+            if HOOK_MARKER in cmd:
+                return True
+    return False

--- a/src/context_engine/memory/hook_server.py
+++ b/src/context_engine/memory/hook_server.py
@@ -1,0 +1,67 @@
+"""Loopback HTTP server for Claude Code hook payloads.
+
+Bound to 127.0.0.1 on a random free port. The port is written to
+`<storage_base>/serve.port` so the hook shell script can find it without
+configuration. No auth — the listener is loopback-only.
+
+Started as a background asyncio task from `_run_serve` (the MCP server
+process). Stopped gracefully on shutdown.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+from pathlib import Path
+
+from aiohttp import web
+
+from context_engine.memory import db as memory_db
+from context_engine.memory.hooks import add_routes
+
+log = logging.getLogger(__name__)
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def start_hook_server(
+    *,
+    storage_base: Path,
+    project_name: str,
+) -> tuple[web.AppRunner, int]:
+    """Spin up the hook HTTP listener. Returns (runner, port).
+
+    Caller is responsible for `await runner.cleanup()` on shutdown.
+    """
+    db_path = memory_db.memory_db_path(storage_base)
+    conn = memory_db.connect(db_path)
+
+    app = web.Application()
+    app["memory_db"] = conn
+    app["project_name"] = project_name
+    add_routes(app)
+
+    async def _close_db(app):
+        try:
+            app["memory_db"].close()
+        except Exception:
+            log.exception("memory_db close failed")
+
+    app.on_cleanup.append(_close_db)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    port = _find_free_port()
+    site = web.TCPSite(runner, host="127.0.0.1", port=port)
+    await site.start()
+
+    port_file = Path(storage_base) / "serve.port"
+    port_file.parent.mkdir(parents=True, exist_ok=True)
+    port_file.write_text(str(port))
+
+    log.info("Memory hook server listening on 127.0.0.1:%d", port)
+    return runner, port

--- a/src/context_engine/memory/hooks.py
+++ b/src/context_engine/memory/hooks.py
@@ -1,0 +1,240 @@
+"""HTTP handlers backing the 5 Claude Code lifecycle hooks.
+
+Endpoints (all loopback-only, no auth):
+    POST /hooks/SessionStart        -> insert sessions row
+    POST /hooks/UserPromptSubmit    -> insert prompts row, enqueue prev-turn compress
+    POST /hooks/PostToolUse         -> insert tool_event + tool_event_payload
+    POST /hooks/Stop                -> mark turn complete, enqueue compress
+    POST /hooks/SessionEnd          -> mark session complete, enqueue rollup
+
+Hooks are best-effort: every write is wrapped so a payload-shape error never
+500s back to the hook script (which is `set -e` shell). On error we log + return
+202 so the user's flow is never blocked. The dashboard surfaces error counts.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from typing import Any
+
+from aiohttp import web
+
+log = logging.getLogger(__name__)
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _now_iso(epoch: int | None = None) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(epoch or _now_epoch()))
+
+
+async def _read_json(request: web.Request) -> dict:
+    try:
+        return await request.json()
+    except Exception as exc:
+        log.warning("Hook payload not JSON: %s", exc)
+        return {}
+
+
+def _conn(request: web.Request) -> sqlite3.Connection:
+    return request.app["memory_db"]
+
+
+async def handle_session_start(request: web.Request) -> web.Response:
+    data = await _read_json(request)
+    session_id = data.get("session_id") or data.get("sessionId")
+    if not session_id:
+        return web.json_response({"error": "session_id required"}, status=400)
+    project = data.get("project") or request.app.get("project_name", "")
+    started_epoch = int(data.get("started_at") or _now_epoch())
+
+    conn = _conn(request)
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO sessions "
+            "(id, project, started_at_epoch, started_at, status) "
+            "VALUES (?, ?, ?, ?, 'active')",
+            (session_id, project, started_epoch, _now_iso(started_epoch)),
+        )
+        conn.commit()
+    except Exception:
+        log.exception("SessionStart insert failed")
+        return web.json_response({"ok": False}, status=202)
+    return web.json_response({"ok": True, "session_id": session_id})
+
+
+async def handle_user_prompt_submit(request: web.Request) -> web.Response:
+    data = await _read_json(request)
+    session_id = data.get("session_id")
+    prompt_text = data.get("prompt_text") or data.get("prompt") or ""
+    prompt_number = data.get("prompt_number")
+    if not session_id:
+        return web.json_response({"error": "session_id required"}, status=400)
+
+    conn = _conn(request)
+    try:
+        if prompt_number is None:
+            row = conn.execute(
+                "SELECT COALESCE(MAX(prompt_number), 0) + 1 AS next "
+                "FROM prompts WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            prompt_number = int(row["next"])
+
+        epoch = _now_epoch()
+        conn.execute(
+            "INSERT OR IGNORE INTO prompts "
+            "(session_id, prompt_number, prompt_text, created_at_epoch, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (session_id, int(prompt_number), str(prompt_text), epoch, _now_iso(epoch)),
+        )
+        conn.execute(
+            "UPDATE sessions SET prompt_count = prompt_count + 1 WHERE id = ?",
+            (session_id,),
+        )
+        # Enqueue previous turn for compression. The session may have N-1
+        # prompts now; compress turn N-1.
+        if int(prompt_number) > 1:
+            _enqueue_compression(
+                conn, kind="turn",
+                session_id=session_id,
+                prompt_number=int(prompt_number) - 1,
+            )
+        conn.commit()
+    except Exception:
+        log.exception("UserPromptSubmit insert failed")
+        return web.json_response({"ok": False}, status=202)
+    return web.json_response({"ok": True, "prompt_number": prompt_number})
+
+
+async def handle_post_tool_use(request: web.Request) -> web.Response:
+    data = await _read_json(request)
+    session_id = data.get("session_id")
+    if not session_id:
+        return web.json_response({"error": "session_id required"}, status=400)
+
+    tool_name = data.get("tool_name", "unknown")
+    tool_input = data.get("tool_input") or data.get("tool_input_json") or {}
+    tool_output = data.get("tool_output") or data.get("tool_output_json") or ""
+    prompt_number = data.get("prompt_number")
+
+    raw_input = tool_input if isinstance(tool_input, str) else json.dumps(tool_input)
+    raw_output = tool_output if isinstance(tool_output, str) else json.dumps(tool_output)
+    size = len(raw_input) + len(raw_output)
+
+    conn = _conn(request)
+    try:
+        if prompt_number is None:
+            row = conn.execute(
+                "SELECT COALESCE(MAX(prompt_number), 0) AS cur FROM prompts "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            prompt_number = int(row["cur"]) or 0
+
+        cur = conn.execute(
+            "INSERT INTO tool_event_payloads (raw_input, raw_output, size_bytes) "
+            "VALUES (?, ?, ?)",
+            (raw_input, raw_output, size),
+        )
+        payload_id = cur.lastrowid
+        epoch = _now_epoch()
+        conn.execute(
+            "INSERT INTO tool_events "
+            "(session_id, prompt_number, tool_name, payload_id, created_at_epoch, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, int(prompt_number), tool_name, payload_id, epoch, _now_iso(epoch)),
+        )
+        conn.commit()
+    except Exception:
+        log.exception("PostToolUse insert failed")
+        return web.json_response({"ok": False}, status=202)
+    return web.json_response({"ok": True})
+
+
+async def handle_stop(request: web.Request) -> web.Response:
+    data = await _read_json(request)
+    session_id = data.get("session_id")
+    prompt_number = data.get("prompt_number")
+    if not session_id:
+        return web.json_response({"error": "session_id required"}, status=400)
+
+    conn = _conn(request)
+    try:
+        if prompt_number is None:
+            row = conn.execute(
+                "SELECT COALESCE(MAX(prompt_number), 0) AS cur FROM prompts "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            prompt_number = int(row["cur"]) or 0
+        if int(prompt_number) > 0:
+            _enqueue_compression(
+                conn, kind="turn",
+                session_id=session_id, prompt_number=int(prompt_number),
+            )
+        conn.commit()
+    except Exception:
+        log.exception("Stop enqueue failed")
+        return web.json_response({"ok": False}, status=202)
+    return web.json_response({"ok": True})
+
+
+async def handle_session_end(request: web.Request) -> web.Response:
+    data = await _read_json(request)
+    session_id = data.get("session_id")
+    exit_reason = data.get("exit_reason") or "normal"
+    if not session_id:
+        return web.json_response({"error": "session_id required"}, status=400)
+
+    conn = _conn(request)
+    try:
+        epoch = _now_epoch()
+        conn.execute(
+            "UPDATE sessions SET status = 'completed', exit_reason = ?, "
+            "ended_at_epoch = ?, ended_at = ? WHERE id = ?",
+            (exit_reason, epoch, _now_iso(epoch), session_id),
+        )
+        _enqueue_compression(
+            conn, kind="session_rollup",
+            session_id=session_id, prompt_number=None,
+        )
+        conn.commit()
+    except Exception:
+        log.exception("SessionEnd update failed")
+        return web.json_response({"ok": False}, status=202)
+    return web.json_response({"ok": True})
+
+
+def _enqueue_compression(
+    conn: sqlite3.Connection,
+    *,
+    kind: str,
+    session_id: str,
+    prompt_number: int | None,
+) -> None:
+    """Add a (kind, session_id, prompt_number) row to pending_compressions.
+
+    UNIQUE(kind, session_id, prompt_number) guards against double-enqueue when
+    a prompt fires both Stop *and* the next UserPromptSubmit's "compress prev"
+    trigger in quick succession.
+    """
+    conn.execute(
+        "INSERT OR IGNORE INTO pending_compressions "
+        "(kind, session_id, prompt_number, enqueued_at_epoch) "
+        "VALUES (?, ?, ?, ?)",
+        (kind, session_id, prompt_number, _now_epoch()),
+    )
+
+
+def add_routes(app: web.Application) -> None:
+    """Attach the 5 hook routes to an existing aiohttp app."""
+    app.router.add_post("/hooks/SessionStart", handle_session_start)
+    app.router.add_post("/hooks/UserPromptSubmit", handle_user_prompt_submit)
+    app.router.add_post("/hooks/PostToolUse", handle_post_tool_use)
+    app.router.add_post("/hooks/Stop", handle_stop)
+    app.router.add_post("/hooks/SessionEnd", handle_session_end)

--- a/tests/memory/test_hook_installer.py
+++ b/tests/memory/test_hook_installer.py
@@ -1,0 +1,119 @@
+"""Tests for hook script + settings.json installation."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from context_engine.memory import hook_installer as hi
+
+
+def test_install_hook_script_writes_executable(tmp_path: Path):
+    target = tmp_path / "cce_hook.sh"
+    created = hi.install_hook_script(target)
+    assert created is True
+    assert target.exists()
+    body = target.read_text()
+    assert body.startswith("#!/bin/sh")
+    assert "curl" in body
+    # Owner exec bit set.
+    assert target.stat().st_mode & stat.S_IXUSR
+
+
+def test_install_hook_script_idempotent(tmp_path: Path):
+    target = tmp_path / "cce_hook.sh"
+    assert hi.install_hook_script(target) is True
+    assert hi.install_hook_script(target) is False
+
+
+def test_install_settings_adds_all_5_hooks(tmp_path: Path):
+    project = tmp_path / "myproj"
+    project.mkdir()
+    summary = hi.install_settings(project)
+    assert sorted(summary["added"]) == sorted(hi.LIFECYCLE_HOOKS)
+    settings_path = project / ".claude" / "settings.json"
+    data = json.loads(settings_path.read_text())
+    for hook_name in hi.LIFECYCLE_HOOKS:
+        bucket = data["hooks"][hook_name]
+        assert len(bucket) == 1
+        cmd = bucket[0]["hooks"][0]["command"]
+        assert hi.HOOK_SCRIPT_NAME in cmd
+        assert hook_name in cmd
+
+
+def test_install_settings_idempotent(tmp_path: Path):
+    project = tmp_path / "myproj"
+    project.mkdir()
+    s1 = hi.install_settings(project)
+    s2 = hi.install_settings(project)
+    assert sorted(s1["added"]) == sorted(hi.LIFECYCLE_HOOKS)
+    assert s2["added"] == []
+    assert sorted(s2["skipped"]) == sorted(hi.LIFECYCLE_HOOKS)
+    # No duplicate entries created.
+    data = json.loads((project / ".claude" / "settings.json").read_text())
+    for hook_name in hi.LIFECYCLE_HOOKS:
+        assert len(data["hooks"][hook_name]) == 1
+
+
+def test_install_settings_preserves_user_hooks(tmp_path: Path):
+    project = tmp_path / "myproj"
+    settings_dir = project / ".claude"
+    settings_dir.mkdir(parents=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text(json.dumps({
+        "hooks": {
+            "SessionStart": [{
+                "matcher": "",
+                "hooks": [{"type": "command", "command": "echo my-existing-hook"}],
+            }],
+        },
+        "enabledPlugins": {"some-plugin": True},
+    }))
+
+    summary = hi.install_settings(project)
+    assert "SessionStart" in summary["added"]
+
+    data = json.loads(settings_path.read_text())
+    # User's plugin config preserved.
+    assert data["enabledPlugins"] == {"some-plugin": True}
+    # User's existing hook still present alongside ours.
+    sb = data["hooks"]["SessionStart"]
+    assert len(sb) == 2
+    cmds = [entry["hooks"][0]["command"] for entry in sb]
+    assert any("my-existing-hook" in c for c in cmds)
+    assert any(hi.HOOK_SCRIPT_NAME in c for c in cmds)
+
+
+def test_uninstall_removes_only_our_entries(tmp_path: Path):
+    project = tmp_path / "myproj"
+    project.mkdir()
+    hi.install_settings(project)
+    settings_path = project / ".claude" / "settings.json"
+    # Add a user-owned hook into the same bucket.
+    data = json.loads(settings_path.read_text())
+    data["hooks"]["SessionStart"].append({
+        "matcher": "",
+        "hooks": [{"type": "command", "command": "echo user"}],
+    })
+    settings_path.write_text(json.dumps(data))
+
+    summary = hi.uninstall_settings(project)
+    assert sorted(summary["removed"]) == sorted(hi.LIFECYCLE_HOOKS)
+
+    data = json.loads(settings_path.read_text())
+    # SessionStart bucket still exists with the user's hook.
+    cmds = [entry["hooks"][0]["command"] for entry in data["hooks"]["SessionStart"]]
+    assert cmds == ["echo user"]
+    # Other buckets removed entirely (they had only ours).
+    for hook_name in ["UserPromptSubmit", "PostToolUse", "Stop", "SessionEnd"]:
+        assert hook_name not in data["hooks"]
+
+
+def test_uninstall_on_missing_settings_is_noop(tmp_path: Path):
+    project = tmp_path / "myproj"
+    project.mkdir()
+    summary = hi.uninstall_settings(project)
+    assert summary["removed"] == []

--- a/tests/memory/test_hooks.py
+++ b/tests/memory/test_hooks.py
@@ -1,0 +1,212 @@
+"""Integration tests for the 5 lifecycle-hook HTTP endpoints."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from context_engine.memory import db as memory_db
+from context_engine.memory.hooks import add_routes
+
+
+@pytest.fixture
+async def hook_app(tmp_path: Path):
+    """An aiohttp Application with the memory db wired up + hook routes."""
+    db_path = tmp_path / "memory.db"
+    conn = memory_db.connect(db_path)
+    app = web.Application()
+    app["memory_db"] = conn
+    app["project_name"] = "demo"
+    add_routes(app)
+    yield app, conn
+    conn.close()
+
+
+async def test_session_start_inserts_session(hook_app, aiohttp_client):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    resp = await client.post(
+        "/hooks/SessionStart",
+        json={"session_id": "abc", "project": "demo", "started_at": 1700000000},
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body == {"ok": True, "session_id": "abc"}
+
+    rows = list(conn.execute("SELECT id, project, status FROM sessions"))
+    assert len(rows) == 1
+    assert rows[0]["id"] == "abc"
+    assert rows[0]["project"] == "demo"
+    assert rows[0]["status"] == "active"
+
+
+async def test_session_start_idempotent(hook_app, aiohttp_client):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    for _ in range(3):
+        resp = await client.post(
+            "/hooks/SessionStart",
+            json={"session_id": "abc", "project": "demo"},
+        )
+        assert resp.status == 200
+    n = conn.execute("SELECT COUNT(*) AS n FROM sessions").fetchone()["n"]
+    assert n == 1
+
+
+async def test_user_prompt_submit_inserts_and_assigns_number(hook_app, aiohttp_client):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "abc", "project": "demo"},
+    )
+    r1 = await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "hello"},
+    )
+    r2 = await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "world"},
+    )
+    assert (await r1.json())["prompt_number"] == 1
+    assert (await r2.json())["prompt_number"] == 2
+
+    rows = list(conn.execute(
+        "SELECT prompt_number, prompt_text FROM prompts ORDER BY prompt_number"
+    ))
+    assert [(r["prompt_number"], r["prompt_text"]) for r in rows] == [
+        (1, "hello"), (2, "world"),
+    ]
+    # Second prompt enqueued compression for prior turn (prompt 1).
+    pending = list(conn.execute(
+        "SELECT kind, session_id, prompt_number FROM pending_compressions"
+    ))
+    assert pending == [{"kind": "turn", "session_id": "abc", "prompt_number": 1}] \
+        if isinstance(pending[0], dict) else len(pending) == 1
+
+
+async def test_post_tool_use_inserts_event_and_payload(hook_app, aiohttp_client):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "abc", "project": "demo"},
+    )
+    await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "hi"},
+    )
+    resp = await client.post(
+        "/hooks/PostToolUse",
+        json={
+            "session_id": "abc",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/foo.py"},
+            "tool_output": "x = 1\n",
+        },
+    )
+    assert resp.status == 200
+    events = list(conn.execute(
+        "SELECT tool_name, payload_id, prompt_number FROM tool_events"
+    ))
+    assert len(events) == 1
+    assert events[0]["tool_name"] == "Read"
+    assert events[0]["prompt_number"] == 1
+    payload_id = events[0]["payload_id"]
+    payload = conn.execute(
+        "SELECT raw_input, raw_output, size_bytes FROM tool_event_payloads "
+        "WHERE id = ?", (payload_id,),
+    ).fetchone()
+    assert "/tmp/foo.py" in payload["raw_input"]
+    assert "x = 1" in payload["raw_output"]
+    assert payload["size_bytes"] > 0
+
+
+async def test_stop_enqueues_turn_compression(hook_app, aiohttp_client):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "abc", "project": "demo"},
+    )
+    await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "hi"},
+    )
+    resp = await client.post(
+        "/hooks/Stop",
+        json={"session_id": "abc"},
+    )
+    assert resp.status == 200
+    pending = list(conn.execute(
+        "SELECT kind, session_id, prompt_number FROM pending_compressions"
+    ))
+    assert any(
+        p["kind"] == "turn" and p["prompt_number"] == 1 for p in pending
+    )
+
+
+async def test_session_end_marks_completed_and_enqueues_rollup(
+    hook_app, aiohttp_client,
+):
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "abc", "project": "demo"},
+    )
+    resp = await client.post(
+        "/hooks/SessionEnd",
+        json={"session_id": "abc", "exit_reason": "normal"},
+    )
+    assert resp.status == 200
+    row = conn.execute(
+        "SELECT status, exit_reason, ended_at_epoch FROM sessions WHERE id = ?",
+        ("abc",),
+    ).fetchone()
+    assert row["status"] == "completed"
+    assert row["exit_reason"] == "normal"
+    assert row["ended_at_epoch"] is not None
+
+    pending = list(conn.execute(
+        "SELECT kind, session_id, prompt_number FROM pending_compressions "
+        "WHERE kind = 'session_rollup'"
+    ))
+    assert len(pending) == 1
+    assert pending[0]["session_id"] == "abc"
+
+
+async def test_missing_session_id_returns_400(hook_app, aiohttp_client):
+    app, _ = hook_app
+    client = await aiohttp_client(app)
+    for endpoint in [
+        "/hooks/SessionStart",
+        "/hooks/UserPromptSubmit",
+        "/hooks/PostToolUse",
+        "/hooks/Stop",
+        "/hooks/SessionEnd",
+    ]:
+        resp = await client.post(endpoint, json={})
+        assert resp.status == 400, f"{endpoint} should require session_id"
+
+
+async def test_compression_queue_dedupes(hook_app, aiohttp_client):
+    """Stop and the next UserPromptSubmit can both enqueue the same turn."""
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "abc", "project": "demo"},
+    )
+    await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "hi"},
+    )
+    await client.post("/hooks/Stop", json={"session_id": "abc"})
+    # Next prompt would also enqueue prev turn (1).
+    await client.post(
+        "/hooks/UserPromptSubmit",
+        json={"session_id": "abc", "prompt_text": "next"},
+    )
+    n = conn.execute(
+        "SELECT COUNT(*) AS n FROM pending_compressions "
+        "WHERE kind = 'turn' AND session_id = 'abc' AND prompt_number = 1"
+    ).fetchone()["n"]
+    assert n == 1, "double-enqueue should be deduped by UNIQUE constraint"


### PR DESCRIPTION
## PR 2 of 5 — Capture

Stacked on PR 1 (foundation). Base: \`feature/memory-claude-mem-parity\`.

Wires the auto-capture half of the system:

- 5 aiohttp handlers in \`src/context_engine/memory/hooks.py\` for SessionStart, UserPromptSubmit, PostToolUse, Stop, SessionEnd. Hook errors return 202 — capture never blocks the user's flow.
- Loopback HTTP listener (\`hook_server.py\`) started as a background task from \`_run_serve\`. Random free port, written to \`<storage_base>/serve.port\` for the shell shim to discover.
- Hook installer (\`hook_installer.py\`) writes \`~/.cce/hooks/cce_hook.sh\` and wires all 5 entries into \`.claude/settings.json\`. Idempotent. Preserves user-added hooks. Wired into \`cce init\`.

## Capture flow per turn

\`\`\`
SessionStart            → INSERT INTO sessions (status='active')
UserPromptSubmit (n)    → INSERT INTO prompts; if n>1 enqueue compress(turn n-1)
PostToolUse             → INSERT INTO tool_event_payloads + tool_events
Stop                    → enqueue compress(turn n)
SessionEnd              → UPDATE sessions SET status='completed';
                          enqueue compress(session_rollup)
\`\`\`

Double-enqueue (Stop + next UserPromptSubmit) is deduped by the UNIQUE constraint on \`pending_compressions(kind, session_id, prompt_number)\`.

## Out of scope (lands later)

- The compression worker that drains \`pending_compressions\` — PR 3.
- \`session_recall\` reading from memory.db instead of JSON — PR 4.
- Dashboard panels — PR 5.

So memory.db starts accumulating real capture data here; recall surface is unchanged from main until PR 4.

## Test plan

- [x] \`pytest tests/memory/\` — 25 tests pass (10 from PR 1, 15 new)
- [x] Full suite: 326 passed, 1 skipped
- [x] \`cce init\` smoke: \`/Users/fazleelahee/bondmedia\` → settings.json has 5 hook entries; cce_hook.sh executable
- [ ] Live shakeout: re-init bondmedia, restart Claude Code, verify rows land in memory.db across a real turn (post-merge of PR 1)