### PR TITLE
feat(memory) PR 3/5: compress — extractive worker in cce serve

### DIFF
--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -2089,6 +2089,20 @@ async def _run_serve(config) -> None:
     except Exception as exc:
         _log.warning("Memory hook server failed to start: %s", exc)
 
+    # Memory compression worker — drains pending_compressions in the background.
+    # Owns its own sqlite connection (sqlite3 connections are not thread-safe).
+    compression_conn = None
+    compression_task = None
+    try:
+        from context_engine.memory import db as memory_db
+        from context_engine.memory.compressor import compression_loop
+        compression_conn = memory_db.connect(memory_db.memory_db_path(storage_base))
+        compression_task = asyncio.create_task(
+            compression_loop(compression_conn, embedder)
+        )
+    except Exception as exc:
+        _log.warning("Memory compression worker failed to start: %s", exc)
+
     watcher_label = " · live watcher active" if watcher else ""
     hook_label = f" · memory hooks :{hook_port}" if hook_port else ""
     print(
@@ -2107,6 +2121,17 @@ async def _run_serve(config) -> None:
             try:
                 await worker_task
             except asyncio.CancelledError:
+                pass
+        if compression_task is not None:
+            compression_task.cancel()
+            try:
+                await compression_task
+            except asyncio.CancelledError:
+                pass
+        if compression_conn is not None:
+            try:
+                compression_conn.close()
+            except Exception:
                 pass
         if hook_runner is not None:
             try:

--- a/src/context_engine/memory/compressor.py
+++ b/src/context_engine/memory/compressor.py
@@ -1,0 +1,212 @@
+"""Background compression worker for the memory store.
+
+Drains `pending_compressions` rows on a fixed interval, calls the extractive
+summariser for each, writes the result to `turn_summaries` (or
+`sessions.rollup_summary` for kind='session_rollup'), and removes the queue
+row. Failures bump the row's `attempts` and log; the row remains queued for
+retry on the next pass.
+
+Designed to run as an asyncio task inside `cce serve`. Single-flight by
+construction — only one worker drains at a time.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+import time
+from typing import Any
+
+from context_engine.memory.extractive import extractive_summary, truncation_summary
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TURN_TOP_K = 3
+_DEFAULT_ROLLUP_TOP_K = 5
+_DEFAULT_INTERVAL_SECONDS = 5.0
+_TOOL_OUTPUT_CHAR_CAP = 1500  # avoid embedding multi-MB tool outputs
+
+
+def compress_turn(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    prompt_number: int,
+    embedder,
+) -> str:
+    """Compute and persist a turn summary. Returns the summary text."""
+    text = _build_turn_text(conn, session_id=session_id, prompt_number=prompt_number)
+    summary, tier = _summarise(text, embedder=embedder, top_k=_DEFAULT_TURN_TOP_K)
+    epoch = int(time.time())
+    conn.execute(
+        "INSERT OR REPLACE INTO turn_summaries "
+        "(session_id, prompt_number, summary, tier, created_at_epoch) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (session_id, prompt_number, summary, tier, epoch),
+    )
+    return summary
+
+
+def compress_session_rollup(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    embedder,
+) -> str:
+    """Compute the session rollup summary from existing turn summaries.
+
+    If a session has no turn_summaries yet (e.g. SessionEnd fired before the
+    worker drained any turns), we fall through to an empty rollup; the
+    session row is still updated so the timeline view shows it as completed.
+    """
+    rows = list(conn.execute(
+        "SELECT summary FROM turn_summaries WHERE session_id = ? "
+        "ORDER BY prompt_number ASC",
+        (session_id,),
+    ))
+    text = "\n".join(r["summary"] for r in rows if r["summary"])
+    if not text:
+        rollup = ""
+        tier = "empty"
+    else:
+        rollup, tier = _summarise(text, embedder=embedder, top_k=_DEFAULT_ROLLUP_TOP_K)
+    epoch = int(time.time())
+    conn.execute(
+        "UPDATE sessions SET rollup_summary = ?, rollup_summary_at_epoch = ? "
+        "WHERE id = ?",
+        (rollup, epoch, session_id),
+    )
+    log.debug("session rollup tier=%s len=%d", tier, len(rollup))
+    return rollup
+
+
+def _build_turn_text(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    prompt_number: int,
+) -> str:
+    """Concatenate prompt + tool inputs/outputs into one big text blob."""
+    parts: list[str] = []
+
+    prompt = conn.execute(
+        "SELECT prompt_text FROM prompts WHERE session_id = ? AND prompt_number = ?",
+        (session_id, prompt_number),
+    ).fetchone()
+    if prompt and prompt["prompt_text"]:
+        parts.append(f"User: {prompt['prompt_text']}")
+
+    events = conn.execute(
+        "SELECT te.tool_name, p.raw_input, p.raw_output FROM tool_events te "
+        "LEFT JOIN tool_event_payloads p ON p.id = te.payload_id "
+        "WHERE te.session_id = ? AND te.prompt_number = ? "
+        "ORDER BY te.id ASC",
+        (session_id, prompt_number),
+    ).fetchall()
+
+    for ev in events:
+        descriptor = _describe_input(ev["tool_name"], ev["raw_input"] or "")
+        parts.append(descriptor)
+        out = (ev["raw_output"] or "").strip()
+        if out:
+            if len(out) > _TOOL_OUTPUT_CHAR_CAP:
+                out = out[:_TOOL_OUTPUT_CHAR_CAP] + "…"
+            parts.append(out)
+    return "\n".join(parts)
+
+
+def _describe_input(tool_name: str, raw_input: str) -> str:
+    """One-line descriptor of a tool invocation for the summary candidates."""
+    if not raw_input:
+        return tool_name
+    try:
+        data = json.loads(raw_input)
+    except (json.JSONDecodeError, ValueError):
+        return f"{tool_name}: {raw_input[:120]}"
+    if not isinstance(data, dict):
+        return f"{tool_name}: {raw_input[:120]}"
+    # Surface common high-signal fields explicitly.
+    for key in ("file_path", "command", "pattern", "path", "query"):
+        if key in data and data[key]:
+            return f"{tool_name} {key}={data[key]!r}"
+    keys = list(data.keys())[:2]
+    return f"{tool_name} {keys}"
+
+
+def _summarise(text: str, *, embedder, top_k: int) -> tuple[str, str]:
+    """Run extractive summarisation, falling back to truncation on failure."""
+    if not text.strip():
+        return "", "empty"
+    if embedder is None:
+        return truncation_summary(text), "truncation"
+    try:
+        out = extractive_summary(text, embedder=embedder, top_k=top_k)
+        return out, "extractive"
+    except Exception:
+        log.exception("extractive failed; falling back to truncation")
+        return truncation_summary(text), "truncation"
+
+
+async def _drain_one(conn: sqlite3.Connection, embedder) -> bool:
+    """Pop and process the oldest pending row. Returns True if work was done.
+
+    The compress functions run synchronously on the event-loop thread.
+    They're fast in practice (<200 ms for a single-turn extractive
+    summary on bge-small) and an in-process call avoids the SQLite
+    cross-thread restriction we'd hit if we tried asyncio.to_thread.
+    """
+    row = conn.execute(
+        "SELECT id, kind, session_id, prompt_number, attempts FROM pending_compressions "
+        "ORDER BY enqueued_at_epoch ASC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        if row["kind"] == "turn":
+            compress_turn(
+                conn,
+                session_id=row["session_id"],
+                prompt_number=row["prompt_number"],
+                embedder=embedder,
+            )
+        else:
+            compress_session_rollup(
+                conn,
+                session_id=row["session_id"],
+                embedder=embedder,
+            )
+        conn.execute("DELETE FROM pending_compressions WHERE id = ?", (row["id"],))
+        conn.commit()
+    except Exception as exc:
+        log.exception("Compression failed for %s/%s/%s",
+                      row["kind"], row["session_id"], row["prompt_number"])
+        conn.execute(
+            "UPDATE pending_compressions SET attempts = attempts + 1, "
+            "last_error = ? WHERE id = ?",
+            (str(exc)[:500], row["id"]),
+        )
+        conn.commit()
+    return True
+
+
+async def compression_loop(
+    conn: sqlite3.Connection,
+    embedder,
+    *,
+    interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run forever, draining the queue between sleeps. Cancellable via task.cancel()."""
+    while True:
+        if stop_event is not None and stop_event.is_set():
+            return
+        try:
+            did_work = await _drain_one(conn, embedder)
+            if not did_work:
+                await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("compression_loop iteration crashed; backing off")
+            await asyncio.sleep(interval_seconds)

--- a/src/context_engine/memory/extractive.py
+++ b/src/context_engine/memory/extractive.py
@@ -1,0 +1,106 @@
+"""Extractive summarisation using the embedding model already loaded for the index.
+
+The summary is always real text from the source — no synthesis, no
+hallucination. Algorithm:
+
+  1. Split candidate text into sentences.
+  2. Embed each with bge-small (or whatever embedder is passed in).
+  3. Compute the centroid as the mean of all embeddings.
+  4. Rank sentences by cosine similarity to the centroid.
+  5. Take the top K, restored to their original order.
+
+Failure modes:
+  - Empty / single-sentence input: return the input verbatim.
+  - Embedder raises: caller falls back to truncation.
+
+This module has no dependency on the rest of the memory package; it operates
+on plain strings and any object exposing `embed_query(str) -> tuple[float]`.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Protocol
+
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+class _EmbedderLike(Protocol):
+    def embed_query(self, query: str) -> Iterable[float]: ...
+
+
+def split_sentences(text: str) -> list[str]:
+    """Coarse sentence split. Good enough for chat-shaped text.
+
+    Newlines are treated as sentence boundaries too — Claude often emits
+    multi-line tool output where each line is its own statement.
+    """
+    pieces: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pieces.extend(s.strip() for s in _SENTENCE_SPLIT.split(line) if s.strip())
+    return pieces
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    # No numpy here — keep this module standalone and free of imports the
+    # caller might not want to pay for in cold paths.
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / ((na ** 0.5) * (nb ** 0.5))
+
+
+def extractive_summary(
+    text: str,
+    *,
+    embedder: _EmbedderLike,
+    top_k: int = 3,
+) -> str:
+    """Return the top-K most central sentences from `text`, in source order.
+
+    Returns the input verbatim if there's nothing to rank.
+    """
+    sentences = split_sentences(text)
+    if len(sentences) <= top_k:
+        return " ".join(sentences) if sentences else text.strip()
+
+    embeddings: list[list[float]] = []
+    for s in sentences:
+        v = list(embedder.embed_query(s))
+        embeddings.append(v)
+
+    if not embeddings or not embeddings[0]:
+        return " ".join(sentences[:top_k])
+
+    dim = len(embeddings[0])
+    centroid = [0.0] * dim
+    for emb in embeddings:
+        for i in range(dim):
+            centroid[i] += emb[i]
+    n = len(embeddings)
+    centroid = [c / n for c in centroid]
+
+    scored = [
+        (i, _cosine(emb, centroid))
+        for i, emb in enumerate(embeddings)
+    ]
+    scored.sort(key=lambda p: p[1], reverse=True)
+    chosen_indices = sorted(i for i, _ in scored[:top_k])
+    return " ".join(sentences[i] for i in chosen_indices)
+
+
+def truncation_summary(text: str, *, max_chars: int = 200) -> str:
+    """Final fallback when the embedder isn't available."""
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"

--- a/tests/memory/test_compressor.py
+++ b/tests/memory/test_compressor.py
@@ -1,0 +1,190 @@
+"""Tests for the background memory compression worker (PR 3)."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from context_engine.memory import db as memory_db
+from context_engine.memory import compressor as memory_compressor
+
+
+class _StubEmbedder:
+    """Same approach as test_extractive — fixed vectors based on a marker."""
+
+    def embed_query(self, text: str) -> list[float]:
+        if "KEY" in text:
+            return [1.0, 0.0]
+        return [0.0, 1.0]
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    c = memory_db.connect(db_path)
+    yield c
+    c.close()
+
+
+def _seed_session(conn, session_id: str = "s1"):
+    conn.execute(
+        "INSERT INTO sessions (id, project, started_at_epoch, started_at) "
+        "VALUES (?, 'demo', 1700000000, '2023-11-14T22:13:20')",
+        (session_id,),
+    )
+
+
+def _seed_turn(conn, session_id: str, prompt_number: int, prompt_text: str):
+    conn.execute(
+        "INSERT INTO prompts (session_id, prompt_number, prompt_text, "
+        "created_at_epoch, created_at) VALUES (?, ?, ?, 1700000000, "
+        "'2023-11-14T22:13:20')",
+        (session_id, prompt_number, prompt_text),
+    )
+
+
+def _seed_tool_event(conn, session_id, prompt_number, tool_name, tool_input, tool_output):
+    cur = conn.execute(
+        "INSERT INTO tool_event_payloads (raw_input, raw_output, size_bytes) "
+        "VALUES (?, ?, ?)",
+        (json.dumps(tool_input), tool_output, len(tool_output)),
+    )
+    pid = cur.lastrowid
+    conn.execute(
+        "INSERT INTO tool_events (session_id, prompt_number, tool_name, "
+        "payload_id, created_at_epoch, created_at) VALUES (?, ?, ?, ?, "
+        "1700000000, '2023-11-14T22:13:20')",
+        (session_id, prompt_number, tool_name, pid),
+    )
+
+
+def test_compress_turn_writes_summary_with_extractive_tier(conn):
+    _seed_session(conn)
+    _seed_turn(conn, "s1", 1, "Look at KEY thing carefully. Also KEY matters here. Random unrelated text.")
+    _seed_tool_event(conn, "s1", 1, "Read", {"file_path": "/tmp/foo.py"}, "KEY appears here too.")
+    conn.commit()
+
+    summary = memory_compressor.compress_turn(
+        conn, session_id="s1", prompt_number=1, embedder=_StubEmbedder(),
+    )
+    conn.commit()
+
+    assert "KEY" in summary
+    row = conn.execute(
+        "SELECT summary, tier FROM turn_summaries "
+        "WHERE session_id = 's1' AND prompt_number = 1"
+    ).fetchone()
+    assert row["tier"] == "extractive"
+    assert "KEY" in row["summary"]
+
+
+def test_compress_turn_falls_back_to_truncation_without_embedder(conn):
+    _seed_session(conn)
+    _seed_turn(conn, "s1", 1, "Some text that is fairly long and would be summarised normally.")
+    conn.commit()
+
+    summary = memory_compressor.compress_turn(
+        conn, session_id="s1", prompt_number=1, embedder=None,
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT tier FROM turn_summaries WHERE session_id = 's1'"
+    ).fetchone()
+    assert row["tier"] == "truncation"
+
+
+def test_session_rollup_combines_turn_summaries(conn):
+    _seed_session(conn)
+    for n, t in enumerate([
+        "First turn KEY discussed.",
+        "Second turn KEY revisited.",
+        "Third turn random other content.",
+    ], start=1):
+        _seed_turn(conn, "s1", n, t)
+    conn.commit()
+
+    for n in range(1, 4):
+        memory_compressor.compress_turn(
+            conn, session_id="s1", prompt_number=n, embedder=_StubEmbedder(),
+        )
+    conn.commit()
+
+    rollup = memory_compressor.compress_session_rollup(
+        conn, session_id="s1", embedder=_StubEmbedder(),
+    )
+    conn.commit()
+    assert "KEY" in rollup
+    row = conn.execute(
+        "SELECT rollup_summary, rollup_summary_at_epoch FROM sessions WHERE id = 's1'"
+    ).fetchone()
+    assert row["rollup_summary"] == rollup
+    assert row["rollup_summary_at_epoch"] is not None
+
+
+def test_session_rollup_with_no_turns_is_empty(conn):
+    _seed_session(conn)
+    conn.commit()
+    rollup = memory_compressor.compress_session_rollup(
+        conn, session_id="s1", embedder=_StubEmbedder(),
+    )
+    conn.commit()
+    assert rollup == ""
+
+
+async def test_drain_one_processes_oldest_pending(conn):
+    _seed_session(conn)
+    _seed_turn(conn, "s1", 1, "Turn one with KEY content here. KEY appears twice. Other text.")
+    conn.execute(
+        "INSERT INTO pending_compressions (kind, session_id, prompt_number, "
+        "enqueued_at_epoch) VALUES ('turn', 's1', 1, 1700000000)"
+    )
+    conn.commit()
+
+    did_work = await memory_compressor._drain_one(conn, _StubEmbedder())
+    assert did_work is True
+
+    pending = conn.execute("SELECT COUNT(*) AS n FROM pending_compressions").fetchone()["n"]
+    assert pending == 0
+
+    summary_row = conn.execute(
+        "SELECT summary, tier FROM turn_summaries WHERE session_id = 's1'"
+    ).fetchone()
+    assert summary_row is not None
+    assert summary_row["tier"] == "extractive"
+
+
+async def test_drain_one_returns_false_when_queue_empty(conn):
+    did_work = await memory_compressor._drain_one(conn, _StubEmbedder())
+    assert did_work is False
+
+
+async def test_compression_loop_drains_then_idles(conn):
+    _seed_session(conn)
+    _seed_turn(conn, "s1", 1, "KEY text here. KEY again. Random.")
+    conn.execute(
+        "INSERT INTO pending_compressions (kind, session_id, prompt_number, "
+        "enqueued_at_epoch) VALUES ('turn', 's1', 1, 1700000000)"
+    )
+    conn.commit()
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        memory_compressor.compression_loop(
+            conn, _StubEmbedder(), interval_seconds=0.05, stop_event=stop,
+        )
+    )
+    # Give the loop one iteration to drain.
+    await asyncio.sleep(0.2)
+    stop.set()
+    try:
+        await asyncio.wait_for(task, timeout=1)
+    except asyncio.TimeoutError:
+        task.cancel()
+
+    summary_row = conn.execute(
+        "SELECT tier FROM turn_summaries WHERE session_id = 's1'"
+    ).fetchone()
+    assert summary_row is not None
+    assert summary_row["tier"] == "extractive"

--- a/tests/memory/test_extractive.py
+++ b/tests/memory/test_extractive.py
@@ -1,0 +1,80 @@
+"""Tests for the extractive summariser (PR 3)."""
+from __future__ import annotations
+
+from context_engine.memory import extractive
+
+
+class _StubEmbedder:
+    """Returns a deterministic vector — the position of the keyword 'KEY'.
+
+    Sentences containing KEY get a vector pointing in one direction; others
+    point in another. Centroid lies near KEY-bearing sentences if more than
+    half the sentences mention it.
+    """
+
+    def embed_query(self, text: str) -> list[float]:
+        if "KEY" in text:
+            return [1.0, 0.0]
+        return [0.0, 1.0]
+
+
+def test_split_sentences_basic():
+    text = "Hello there. How are you? I am fine!"
+    assert extractive.split_sentences(text) == [
+        "Hello there.", "How are you?", "I am fine!",
+    ]
+
+
+def test_split_sentences_handles_newlines():
+    text = "Line one.\nLine two\nLine three.\n\n"
+    out = extractive.split_sentences(text)
+    assert "Line one." in out
+    assert "Line two" in out
+    assert "Line three." in out
+
+
+def test_extractive_returns_centroid_neighbours():
+    text = (
+        "KEY one is special. "
+        "KEY two also matters. "
+        "KEY three is here. "
+        "Random noise. "
+        "Another distractor."
+    )
+    summary = extractive.extractive_summary(
+        text, embedder=_StubEmbedder(), top_k=3,
+    )
+    # Top 3 should all be KEY-bearing sentences (since 3/5 sentences carry
+    # KEY, the centroid points toward them).
+    assert summary.count("KEY") == 3
+
+
+def test_extractive_short_input_returns_verbatim():
+    text = "Only one sentence here."
+    summary = extractive.extractive_summary(
+        text, embedder=_StubEmbedder(), top_k=3,
+    )
+    assert summary == "Only one sentence here."
+
+
+def test_extractive_preserves_source_order():
+    text = "First. Second. Third. Fourth. Fifth."
+    summary = extractive.extractive_summary(
+        text, embedder=_StubEmbedder(), top_k=3,
+    )
+    # The stub gives all sentences identical embeddings (none have KEY),
+    # so any 3 are equally central. Whatever 3 we pick must be in source
+    # order — verify by checking for monotonic substring positions.
+    positions = [text.find(s) for s in summary.split() if s.endswith(".")]
+    assert positions == sorted(positions)
+
+
+def test_truncation_summary_short_input():
+    assert extractive.truncation_summary("hi") == "hi"
+
+
+def test_truncation_summary_long_input():
+    text = "x" * 500
+    out = extractive.truncation_summary(text, max_chars=50)
+    assert len(out) == 50
+    assert out.endswith("…")

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -391,6 +392,7 @@ http = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
 ]
@@ -405,6 +407,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-aiohttp", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -422,6 +425,7 @@ provides-extras = ["dev", "http"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-aiohttp", specifier = ">=1.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-xdist", specifier = ">=3.5" },
 ]
@@ -1730,6 +1734,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-aiohttp"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4b/d326890c153f2c4ce1bf45d07683c08c10a1766058a22934620bc6ac6592/pytest_aiohttp-1.1.0.tar.gz", hash = "sha256:147de8cb164f3fc9d7196967f109ab3c0b93ea3463ab50631e56438eab7b5adc", size = 12842, upload-time = "2025-01-23T12:44:04.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/0f/e6af71c02e0f1098eaf7d2dbf3ffdf0a69fc1e0ef174f96af05cef161f1b/pytest_aiohttp-1.1.0-py3-none-any.whl", hash = "sha256:f39a11693a0dce08dd6c542d241e199dd8047a6e6596b2bcfa60d373f143456d", size = 8932, upload-time = "2025-01-23T12:44:03.27Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR 3 of 5 — Compress

Stacked on PR 2 (capture). Base: \`feature/memory-pr2-capture\`.

Implements the background compression worker that drains \`pending_compressions\` and writes turn summaries + session rollups.

## What's added

- **\`memory/extractive.py\`** — sentence splitter + centroid-based extractive summarisation. No new dependencies. Operates on any embedder exposing \`embed_query(str)\`. Always returns real source text — no synthesis, no hallucination.
- **\`memory/compressor.py\`** — \`compress_turn()\` and \`compress_session_rollup()\` plus the \`compression_loop()\` async drain. Uses the bge-small embedder already loaded for the index. Falls back to truncation if the embedder is unavailable.
- **\`_run_serve\` (cli.py)** — spawns the worker alongside the hook server, with its own sqlite connection (avoids cross-thread issues with sqlite3). Cancelled and closed gracefully on shutdown.

## Tier behaviour

| Tier | When | Quality |
|---|---|---|
| \`extractive\` | default — bge-small loaded | top-K centroid sentences |
| \`truncation\` | embedder None or extractive raises | first 200 chars + ellipsis |
| \`empty\` | no candidate text (e.g. SessionEnd before any turn drained) | "" |

## Out of scope (lands later)

- Recall: \`session_recall\` still reads from JSON. Lands in PR 4.
- Dashboard panels: PR 5.

## Test plan

- [x] \`pytest tests/memory/\` — 39 tests (14 new for PR 3)
- [x] Full suite: 340 passed, 1 skipped
- [ ] Live shakeout post-merge: verify extractive summaries land in \`turn_summaries\` after a real Claude Code turn