### PR TITLE
feat(memory) PR 5/5: dashboard — sessions list, timeline, decisions search

### DIFF
--- a/src/context_engine/dashboard/_page.py
+++ b/src/context_engine/dashboard/_page.py
@@ -565,6 +565,11 @@ body { background: var(--bg2); color: var(--text); font-family: var(--sans); fon
       <span class="nav-count" id="nav-sessions-count">\u2014</span>
     </button>
 
+    <button class="nav-item" onclick="showPage('memory')">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9 1.65 1.65 0 0 0 4.27 7.18l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      Memory
+    </button>
+
     <div class="nav-section-label" style="margin-top:4px">Analytics</div>
 
     <button class="nav-item" onclick="showPage('savings')">
@@ -812,6 +817,63 @@ body { background: var(--bg2); color: var(--text); font-family: var(--sans); fon
       </div>
     </div>
 
+    <!-- ═══════════════════ MEMORY ═══════════════════ -->
+    <div class="page" id="page-memory">
+      <div class="page-hdr">
+        <div class="page-hdr-left">
+          <div class="page-hdr-title">Memory</div>
+          <div class="page-hdr-sub">Cross-session memory store (memory.db) — sessions, timelines, decisions</div>
+        </div>
+        <div class="page-hdr-right">
+          <div class="comp-grid" style="display:flex; gap:6px">
+            <button class="comp-btn comp-btn-active" id="mem-tab-sessions" onclick="memShowTab('sessions')">Sessions</button>
+            <button class="comp-btn" id="mem-tab-decisions" onclick="memShowTab('decisions')">Decisions</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Sessions list + drill-down view (kept side by side; the drill panel
+           appears when a session is selected). -->
+      <div class="memory-pane" id="mem-pane-sessions">
+        <div class="data-table">
+          <div class="table-head"><div>Session</div><div>Started</div><div>Status</div><div>Prompts</div><div>Rollup</div></div>
+          <div id="mem-sessions-rows"></div>
+        </div>
+
+        <div class="panel" id="mem-timeline-panel" style="margin-top:14px; display:none">
+          <div class="panel-head">
+            <div class="panel-title" id="mem-timeline-title">Session timeline</div>
+          </div>
+          <div class="panel-body" id="mem-timeline-body"></div>
+        </div>
+      </div>
+
+      <!-- Decisions search -->
+      <div class="memory-pane" id="mem-pane-decisions" style="display:none">
+        <div class="panel">
+          <div class="panel-head">
+            <div class="panel-title">Decisions search</div>
+          </div>
+          <div class="panel-body">
+            <div style="display:flex; gap:8px; margin-bottom:10px">
+              <input id="mem-decision-q" type="text" placeholder="search decisions (FTS5)…" style="flex:1; padding:6px 10px; background:var(--panel2); border:1px solid var(--border); color:var(--text); border-radius:4px">
+              <select id="mem-decision-source" style="padding:6px 10px; background:var(--panel2); border:1px solid var(--border); color:var(--text); border-radius:4px">
+                <option value="">all sources</option>
+                <option value="manual">manual</option>
+                <option value="auto">auto</option>
+                <option value="migrated">migrated</option>
+              </select>
+              <button class="comp-btn" onclick="memDecisionSearch()">search</button>
+            </div>
+            <div class="data-table">
+              <div class="table-head"><div>Decision</div><div>Reason</div><div>Source</div><div>When</div></div>
+              <div id="mem-decision-rows"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </main>
 </div>
 
@@ -821,7 +883,7 @@ body { background: var(--bg2); color: var(--text); font-family: var(--sans); fon
 var API = '';
 var allFiles = [];
 var currentLevel = 'standard';
-var PAGES = ['overview','files','sessions','savings'];
+var PAGES = ['overview','files','sessions','memory','savings'];
 
 // Pick up an optional bearer token from the URL (?token=...). The server
 // only enforces it on mutating endpoints when CCE_DASHBOARD_TOKEN is set;
@@ -981,7 +1043,111 @@ function showPage(name) {
   });
   if (name==='files')    loadFiles();
   if (name==='sessions') loadSessions();
+  if (name==='memory')   loadMemorySessions();
   if (name==='savings')  loadSavings();
+}
+
+// ── Memory page (PR 5) ───────────────────────────
+
+function memShowTab(tab) {
+  document.getElementById('mem-pane-sessions').style.display  = tab==='sessions'  ? '' : 'none';
+  document.getElementById('mem-pane-decisions').style.display = tab==='decisions' ? '' : 'none';
+  document.getElementById('mem-tab-sessions').classList.toggle('comp-btn-active', tab==='sessions');
+  document.getElementById('mem-tab-decisions').classList.toggle('comp-btn-active', tab==='decisions');
+  if (tab==='decisions') memDecisionSearch();
+}
+
+function _esc(s) {
+  return String(s||'').replace(/[&<>"']/g, function(c) {
+    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+  });
+}
+
+async function loadMemorySessions() {
+  try {
+    var r = await fetch(API+'/api/memory/sessions');
+    var rows = await r.json();
+    var box = document.getElementById('mem-sessions-rows');
+    if (!rows.length) {
+      box.innerHTML = '<div class="empty">No sessions captured yet. Start a Claude Code session in this project — hooks will populate the timeline.</div>';
+      return;
+    }
+    box.innerHTML = rows.map(function(s) {
+      var rollup = (s.rollup_summary || '').slice(0, 80);
+      return ''
+        + '<div class="table-row" onclick="loadMemoryTimeline(\''+_esc(s.id)+'\')" style="cursor:pointer">'
+        +   '<div><code>'+_esc(s.id)+'</code></div>'
+        +   '<div>'+_esc(s.started_at||'')+'</div>'
+        +   '<div>'+_esc(s.status||'')+'</div>'
+        +   '<div>'+_esc(s.prompt_count||0)+'</div>'
+        +   '<div>'+_esc(rollup)+(rollup && s.rollup_summary && s.rollup_summary.length>80?'…':'')+'</div>'
+        + '</div>';
+    }).join('');
+  } catch(e) {
+    document.getElementById('mem-sessions-rows').innerHTML =
+      '<div class="empty">Memory store unavailable.</div>';
+  }
+}
+
+async function loadMemoryTimeline(sessionId) {
+  try {
+    var r = await fetch(API+'/api/memory/sessions/'+encodeURIComponent(sessionId)+'/timeline');
+    var data = await r.json();
+    var panel = document.getElementById('mem-timeline-panel');
+    var title = document.getElementById('mem-timeline-title');
+    var body  = document.getElementById('mem-timeline-body');
+    panel.style.display = '';
+    title.textContent = 'Session ' + sessionId;
+    if (!data.session || !data.turns.length) {
+      body.innerHTML = '<div class="empty">No turn summaries yet for this session.</div>';
+      return;
+    }
+    var rollup = data.session.rollup_summary
+      ? '<div style="margin-bottom:10px; padding:8px; background:var(--panel2); border-radius:4px"><strong>rollup:</strong> '+_esc(data.session.rollup_summary)+'</div>'
+      : '';
+    var turns = data.turns.map(function(t) {
+      return ''
+        + '<div style="padding:6px 0; border-bottom:1px solid var(--border)">'
+        +   '<div style="font-size:11px; color:var(--muted)">turn '+t.prompt_number+' · ['+_esc(t.tier)+']</div>'
+        +   '<div>'+_esc(t.summary)+'</div>'
+        + '</div>';
+    }).join('');
+    body.innerHTML = rollup + turns;
+  } catch(e) {
+    document.getElementById('mem-timeline-body').innerHTML =
+      '<div class="empty">Failed to load timeline.</div>';
+  }
+}
+
+async function memDecisionSearch() {
+  var q = (document.getElementById('mem-decision-q').value || '').trim();
+  var src = document.getElementById('mem-decision-source').value || '';
+  var url = API+'/api/memory/decisions';
+  var params = [];
+  if (q) params.push('q='+encodeURIComponent(q));
+  if (src) params.push('source='+encodeURIComponent(src));
+  if (params.length) url += '?' + params.join('&');
+  try {
+    var r = await fetch(url);
+    var rows = await r.json();
+    var box = document.getElementById('mem-decision-rows');
+    if (!rows.length) {
+      box.innerHTML = '<div class="empty">No decisions match.</div>';
+      return;
+    }
+    box.innerHTML = rows.map(function(d) {
+      return ''
+        + '<div class="table-row">'
+        +   '<div>'+_esc(d.decision)+'</div>'
+        +   '<div>'+_esc(d.reason)+'</div>'
+        +   '<div><span class="tag tag-'+_esc(d.source)+'">'+_esc(d.source)+'</span></div>'
+        +   '<div>'+_esc(d.created_at||'')+'</div>'
+        + '</div>';
+    }).join('');
+  } catch(e) {
+    document.getElementById('mem-decision-rows').innerHTML =
+      '<div class="empty">Decisions search failed.</div>';
+  }
 }
 
 function toast(msg) {

--- a/src/context_engine/dashboard/server.py
+++ b/src/context_engine/dashboard/server.py
@@ -188,6 +188,109 @@ def create_app(config: Config, project_dir: Path) -> FastAPI:
     async def get_sessions() -> list:
         return _read_sessions()
 
+    # ── memory.db API (PR 5) ────────────────────────────────────────────────
+    # These endpoints expose the per-project memory.db introduced in PRs 1–4.
+    # All queries open a fresh connection (cheap on SQLite WAL) so the
+    # dashboard process never holds a long-lived handle that would block the
+    # MCP server's writes.
+
+    def _open_memory_conn():
+        from context_engine.memory import db as memory_db
+        path = memory_db.memory_db_path(storage_base)
+        if not path.exists():
+            return None
+        return memory_db.connect(path)
+
+    @app.get("/api/memory/sessions")
+    async def memory_sessions_list(limit: int = 50) -> list:
+        """Sessions list: most-recent first. Limited to `limit` rows."""
+        conn = _open_memory_conn()
+        if conn is None:
+            return []
+        try:
+            rows = list(conn.execute(
+                "SELECT id, project, started_at, ended_at, status, "
+                "prompt_count, rollup_summary FROM sessions "
+                "ORDER BY started_at_epoch DESC LIMIT ?",
+                (max(1, min(limit, 500)),),
+            ))
+        finally:
+            conn.close()
+        return [dict(r) for r in rows]
+
+    @app.get("/api/memory/sessions/{session_id}/timeline")
+    async def memory_session_timeline(session_id: str) -> dict:
+        """A single session's turn summaries plus header metadata."""
+        conn = _open_memory_conn()
+        if conn is None:
+            return {"session": None, "turns": []}
+        try:
+            session_row = conn.execute(
+                "SELECT id, project, started_at, ended_at, status, "
+                "prompt_count, rollup_summary FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session_row is None:
+                return {"session": None, "turns": []}
+            turn_rows = list(conn.execute(
+                "SELECT prompt_number, summary, tier, created_at_epoch "
+                "FROM turn_summaries WHERE session_id = ? "
+                "ORDER BY prompt_number ASC",
+                (session_id,),
+            ))
+        finally:
+            conn.close()
+        return {
+            "session": dict(session_row),
+            "turns": [dict(r) for r in turn_rows],
+        }
+
+    @app.get("/api/memory/decisions")
+    async def memory_decisions_search(
+        q: str = "", source: str | None = None, limit: int = 50
+    ) -> list:
+        """FTS5 search over decisions, optionally filtered by source."""
+        conn = _open_memory_conn()
+        if conn is None:
+            return []
+        limit = max(1, min(limit, 500))
+        try:
+            params: list = []
+            sql = (
+                "SELECT d.id, d.session_id, d.decision, d.reason, d.source, "
+                "d.created_at FROM decisions d "
+            )
+            if q.strip():
+                sql += (
+                    "JOIN decisions_fts ON decisions_fts.rowid = d.id "
+                    "WHERE decisions_fts MATCH ? "
+                )
+                # Wrap in a phrase quote so FTS5's tokeniser treats user
+                # input as literal text — without this, characters like '-'
+                # parse as operators (`bge-small` becomes "bge AND NOT
+                # small") and queries silently miss real hits.
+                params.append('"' + q.strip().replace('"', '""') + '"')
+            else:
+                sql += "WHERE 1=1 "
+            if source in {"manual", "auto", "migrated"}:
+                sql += "AND d.source = ? "
+                params.append(source)
+            sql += "ORDER BY d.created_at_epoch DESC LIMIT ?"
+            params.append(limit)
+            try:
+                rows = list(conn.execute(sql, params))
+            except Exception:
+                # FTS5 syntax errors on weird queries — fall back to unranked.
+                rows = list(conn.execute(
+                    "SELECT id, session_id, decision, reason, source, "
+                    "created_at FROM decisions ORDER BY created_at_epoch "
+                    "DESC LIMIT ?",
+                    (limit,),
+                ))
+        finally:
+            conn.close()
+        return [dict(r) for r in rows]
+
     @app.get("/api/savings")
     async def get_savings() -> dict:
         stats = _read_stats()

--- a/tests/dashboard/test_memory_endpoints.py
+++ b/tests/dashboard/test_memory_endpoints.py
@@ -1,0 +1,164 @@
+"""Tests for the memory.db dashboard API endpoints (PR 5)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from context_engine.config import Config
+from context_engine.dashboard.server import create_app
+from context_engine.memory import db as memory_db
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    project_dir = tmp_path / "demo"
+    project_dir.mkdir()
+    storage_path = tmp_path / "storage"
+    storage_path.mkdir()
+    project_storage = storage_path / "demo"
+    project_storage.mkdir()
+
+    # Minimal manifest so /api/files / /api/status work.
+    (project_storage / "manifest.json").write_text(
+        json.dumps({"__schema_version": 2, "files": {}, "last_git_sha": None})
+    )
+
+    config = Config(
+        storage_path=str(storage_path),
+        embedding_model="BAAI/bge-small-en-v1.5",
+    )
+    app = create_app(config, project_dir)
+    return TestClient(app), project_storage
+
+
+def _seed_memory_db(project_storage: Path):
+    """Open or create memory.db in the project's storage dir; seed sample data."""
+    db_path = memory_db.memory_db_path(project_storage)
+    conn = memory_db.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (id, project, started_at_epoch, started_at, "
+        "status, prompt_count, rollup_summary) VALUES "
+        "('s-recent', 'demo', 1700000200, '2023-11-14T22:16:40', 'completed', "
+        "2, 'A two-turn rollup summary')"
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, project, started_at_epoch, started_at, "
+        "status, prompt_count) VALUES "
+        "('s-old', 'demo', 1700000000, '2023-11-14T22:13:20', 'completed', 0)"
+    )
+    conn.execute(
+        "INSERT INTO turn_summaries (session_id, prompt_number, summary, tier, "
+        "created_at_epoch) VALUES ('s-recent', 1, 'first turn KEY', "
+        "'extractive', 1700000210)"
+    )
+    conn.execute(
+        "INSERT INTO turn_summaries (session_id, prompt_number, summary, tier, "
+        "created_at_epoch) VALUES ('s-recent', 2, 'second turn KEY again', "
+        "'extractive', 1700000220)"
+    )
+    conn.execute(
+        "INSERT INTO decisions (session_id, decision, reason, source, "
+        "created_at_epoch, created_at) VALUES "
+        "('s-recent', 'Use bge-small for KEY recall', 'Already loaded', "
+        "'manual', 1700000230, '2023-11-14T22:17:10')"
+    )
+    conn.execute(
+        "INSERT INTO decisions (session_id, decision, reason, source, "
+        "created_at_epoch, created_at) VALUES "
+        "(NULL, 'Migrated decision X', 'old reason', 'migrated', 1699000000, "
+        "'2023-11-03T11:46:40')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_memory_sessions_returns_recent_first(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/sessions")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [r["id"] for r in rows] == ["s-recent", "s-old"]
+    assert rows[0]["rollup_summary"] == "A two-turn rollup summary"
+
+
+def test_memory_sessions_empty_when_no_db(client):
+    c, _ = client
+    resp = c.get("/api/memory/sessions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_memory_session_timeline_returns_session_and_turns(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/sessions/s-recent/timeline")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session"]["id"] == "s-recent"
+    assert data["session"]["rollup_summary"] == "A two-turn rollup summary"
+    assert len(data["turns"]) == 2
+    assert data["turns"][0]["prompt_number"] == 1
+    assert data["turns"][1]["prompt_number"] == 2
+    assert data["turns"][0]["tier"] == "extractive"
+
+
+def test_memory_session_timeline_unknown_returns_null(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/sessions/no-such/timeline")
+    assert resp.status_code == 200
+    assert resp.json() == {"session": None, "turns": []}
+
+
+def test_memory_decisions_search_fts(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/decisions?q=bge-small")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["source"] == "manual"
+
+
+def test_memory_decisions_search_filters_by_source(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/decisions?source=migrated")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["source"] == "migrated"
+
+
+def test_memory_decisions_no_query_returns_all_recent(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/decisions")
+    rows = resp.json()
+    assert len(rows) == 2
+    assert rows[0]["source"] == "manual"  # most-recent first
+    assert rows[1]["source"] == "migrated"
+
+
+def test_memory_decisions_combined_filters(client):
+    c, storage = client
+    _seed_memory_db(storage)
+    resp = c.get("/api/memory/decisions?q=bge-small&source=migrated")
+    rows = resp.json()
+    assert rows == []
+
+
+def test_memory_decisions_handles_special_chars(client):
+    """User input with FTS5 metacharacters is treated literally (phrase quoted)."""
+    c, storage = client
+    _seed_memory_db(storage)
+    # Hyphen would parse as an FTS5 operator without phrase-quoting.
+    resp = c.get("/api/memory/decisions?q=bge-small")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert "bge-small" in rows[0]["decision"]


### PR DESCRIPTION
## PR 5 of 5 — Dashboard (final PR in series)

Stacked on PR 4 (recall). Base: \`feature/memory-pr4-recall\`.

Closes out the memory.db ↔ claude-mem parity work with three dashboard panels in the existing CCE dashboard.

## Endpoints (server.py)

| Endpoint | Returns |
|---|---|
| \`GET /api/memory/sessions[?limit]\` | sessions list, most-recent first |
| \`GET /api/memory/sessions/{id}/timeline\` | session metadata + turn summaries |
| \`GET /api/memory/decisions[?q&source]\` | FTS5 search; source facet manual\|auto\|migrated |

User query is phrase-quoted before passing to FTS5 — handles \`bge-small\` and other hyphenated terms literally instead of parsing as boolean.

## UI (\_page.py)

- New "Memory" sidebar entry.
- Tab toggle: Sessions / Decisions.
- Sessions tab: list → click row → timeline panel with rollup + per-turn summaries.
- Decisions tab: text search + source dropdown.

## Test plan

- [x] \`pytest\` — full suite 359 passed, 1 skipped (9 new for PR 5)
- [ ] Live shakeout post-merge: open dashboard against bondmedia/sonin and verify Memory page renders with seeded data

## Series status

| PR | URL | Status |
|---|---|---|
| 1. Foundation | #2 | ready for review |
| 2. Capture | #3 | ready for review |
| 3. Compress | #4 | ready for review |
| 4. Recall | #5 | ready for review |
| **5. Dashboard** | this PR | ready for review |