### PR TITLE
fix(memory): post-merge audit cleanup — 8 items

### DIFF
--- a/scripts/bench_recall.py
+++ b/scripts/bench_recall.py
@@ -236,11 +236,14 @@ def _returned_indices(mcp, query: str) -> list[int]:
     expand(compress(...)) of each candidate — the same round-trip the
     real pipeline does — and look for that.
     """
-    from context_engine.memory.grammar import compress, expand
+    # Use the same compression level the source code applies on write —
+    # otherwise this canonical match is comparing against a different shape
+    # than what landed in memory.db.
+    from context_engine.memory.grammar import compress, expand, DEFAULT_LEVEL
 
     matches = mcp._search_sessions(query)
     canonical = [
-        expand(compress(f"{d} — {r}", level="lite"))
+        expand(compress(f"{d} — {r}", level=DEFAULT_LEVEL))
         for _, d, r in CORPUS
     ]
     indices: list[int] = []
@@ -303,10 +306,13 @@ def run_bench(args) -> dict:
     # CORPUS-seeded memory.db, so this measures end-to-end (extractive +
     # grammar combined when the row goes through compress_turn; for the
     # decisions table it's just grammar).
-    from context_engine.memory.grammar import compress as _g_compress
+    from context_engine.memory.grammar import (
+        compress as _g_compress,
+        DEFAULT_LEVEL as _G_LEVEL,
+    )
     original_bytes = sum(len(d) + len(r) for _, d, r in CORPUS)
     compressed_bytes = sum(
-        len(_g_compress(d, level="lite")) + len(_g_compress(r, level="lite"))
+        len(_g_compress(d, level=_G_LEVEL)) + len(_g_compress(r, level=_G_LEVEL))
         for _, d, r in CORPUS
     )
 

--- a/src/context_engine/dashboard/server.py
+++ b/src/context_engine/dashboard/server.py
@@ -203,7 +203,13 @@ def create_app(config: Config, project_dir: Path) -> FastAPI:
 
     @app.get("/api/memory/sessions")
     async def memory_sessions_list(limit: int = 50) -> list:
-        """Sessions list: most-recent first. Limited to `limit` rows."""
+        """Sessions list: most-recent first. Limited to `limit` rows.
+
+        Stored `rollup_summary` was passed through grammar.compress on write;
+        we expand here so the dashboard renders natural prose, not the
+        article-stripped storage form.
+        """
+        from context_engine.memory.grammar import expand as _grammar_expand
         conn = _open_memory_conn()
         if conn is None:
             return []
@@ -216,11 +222,18 @@ def create_app(config: Config, project_dir: Path) -> FastAPI:
             ))
         finally:
             conn.close()
-        return [dict(r) for r in rows]
+        out = []
+        for r in rows:
+            d = dict(r)
+            if d.get("rollup_summary"):
+                d["rollup_summary"] = _grammar_expand(d["rollup_summary"])
+            out.append(d)
+        return out
 
     @app.get("/api/memory/sessions/{session_id}/timeline")
     async def memory_session_timeline(session_id: str) -> dict:
         """A single session's turn summaries plus header metadata."""
+        from context_engine.memory.grammar import expand as _grammar_expand
         conn = _open_memory_conn()
         if conn is None:
             return {"session": None, "turns": []}
@@ -240,10 +253,16 @@ def create_app(config: Config, project_dir: Path) -> FastAPI:
             ))
         finally:
             conn.close()
-        return {
-            "session": dict(session_row),
-            "turns": [dict(r) for r in turn_rows],
-        }
+        session_d = dict(session_row)
+        if session_d.get("rollup_summary"):
+            session_d["rollup_summary"] = _grammar_expand(session_d["rollup_summary"])
+        turns = []
+        for r in turn_rows:
+            d = dict(r)
+            if d.get("summary"):
+                d["summary"] = _grammar_expand(d["summary"])
+            turns.append(d)
+        return {"session": session_d, "turns": turns}
 
     @app.get("/api/memory/decisions")
     async def memory_decisions_search(
@@ -289,7 +308,17 @@ def create_app(config: Config, project_dir: Path) -> FastAPI:
                 ))
         finally:
             conn.close()
-        return [dict(r) for r in rows]
+        # Stored decision/reason are compressed; expand for display.
+        from context_engine.memory.grammar import expand as _grammar_expand
+        out = []
+        for r in rows:
+            d = dict(r)
+            if d.get("decision"):
+                d["decision"] = _grammar_expand(d["decision"])
+            if d.get("reason"):
+                d["reason"] = _grammar_expand(d["reason"])
+            out.append(d)
+        return out
 
     @app.get("/api/savings")
     async def get_savings() -> dict:

--- a/src/context_engine/integration/mcp_server.py
+++ b/src/context_engine/integration/mcp_server.py
@@ -24,7 +24,11 @@ from context_engine.integration.git_context import (
 from context_engine.integration.session_capture import SessionCapture
 from context_engine.memory import db as memory_db
 from context_engine.memory.extractive import extractive_summary
-from context_engine.memory.grammar import compress as _grammar_compress, expand as _grammar_expand
+from context_engine.memory.grammar import (
+    compress as _grammar_compress,
+    expand as _grammar_expand,
+    DEFAULT_LEVEL as _GRAMMAR_LEVEL,
+)
 
 log = logging.getLogger(__name__)
 
@@ -116,14 +120,21 @@ def _strip_tag(text: str) -> str:
 
 
 def _content_key(text: str) -> str:
-    """Stable dedup key for a recall match. Strips both the [tag] prefix and
-    the " · 5m ago · → session_timeline(...)" affordance suffix so the same
-    decision rendered through different code paths (memory.db with hints,
-    JSON history without) collapses to one entry under RRF.
+    """Stable dedup key for a recall match.
+
+    Strips:
+      1. The `[tag]` prefix the formatter adds.
+      2. The " · 5m ago · → session_timeline(...)" affordance suffix.
+      3. Articles (via grammar.compress at lite level), so the SAME decision
+         stored compressed in memory.db and stored raw in JSON history
+         collapses to one canonical key. Without (3), `_handle_record_decision`
+         dual-writes produce two recall hits in the dual-write window — one
+         from memory.db ("Adopt JWT") and one from JSON ("Adopt the JWT") —
+         that look distinct to RRF but are the same decision.
     """
     body = _TAG_PREFIX_RE.sub("", text)
     body = _AFFORDANCE_TAIL_RE.sub("", body)
-    return body.strip()
+    return _grammar_compress(body.strip(), level="lite")
 
 
 def _humanise_relative_time(epoch: int | None) -> str:
@@ -910,8 +921,8 @@ class ContextEngineMCP:
             try:
                 import time as _time
                 epoch = int(_time.time())
-                stored_decision = _grammar_compress(decision, level="lite")
-                stored_reason = _grammar_compress(reason, level="lite")
+                stored_decision = _grammar_compress(decision, level=_GRAMMAR_LEVEL)
+                stored_reason = _grammar_compress(reason, level=_GRAMMAR_LEVEL)
                 cur = self._memory_conn.execute(
                     "INSERT INTO decisions (session_id, decision, reason, source, "
                     "created_at_epoch, created_at) "

--- a/src/context_engine/memory/compressor.py
+++ b/src/context_engine/memory/compressor.py
@@ -19,7 +19,10 @@ import time
 
 from context_engine.memory import db as memory_db
 from context_engine.memory.extractive import extractive_summary, truncation_summary
-from context_engine.memory.grammar import compress as _grammar_compress
+from context_engine.memory.grammar import (
+    compress as _grammar_compress,
+    DEFAULT_LEVEL as _GRAMMAR_LEVEL,
+)
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +54,7 @@ def compress_turn(
     text = _build_turn_text(conn, session_id=session_id, prompt_number=prompt_number)
     summary, tier = _summarise(text, embedder=embedder, top_k=_DEFAULT_TURN_TOP_K)
     if summary:
-        summary = _grammar_compress(summary, level="lite")
+        summary = _grammar_compress(summary, level=_GRAMMAR_LEVEL)
     epoch = int(time.time())
     cur = conn.execute(
         "INSERT OR REPLACE INTO turn_summaries "
@@ -93,7 +96,7 @@ def compress_session_rollup(
         # so this is mostly idempotent, but extractive may concatenate
         # sentences with newlines that re-introduce articles via the join
         # mechanics. Cheap, makes the on-disk form consistent.
-        rollup = _grammar_compress(rollup, level="lite")
+        rollup = _grammar_compress(rollup, level=_GRAMMAR_LEVEL)
     epoch = int(time.time())
     conn.execute(
         "UPDATE sessions SET rollup_summary = ?, rollup_summary_at_epoch = ? "

--- a/src/context_engine/memory/grammar.py
+++ b/src/context_engine/memory/grammar.py
@@ -35,6 +35,13 @@ from typing import Literal
 
 Level = Literal["lite", "full", "ultra"]
 
+# Single source of truth for the compression level applied to memory.db
+# storage. Imported by mcp_server (record_decision), compressor (turn +
+# rollup), migrate (legacy import), and the bench (canonical-form match).
+# All five paths must agree, otherwise the bench gives misleading numbers
+# and the same decision can land in storage at different shapes.
+DEFAULT_LEVEL: Level = "lite"
+
 
 # ── Token classes ──────────────────────────────────────────────────────────
 # Any string fragment that matches a structured-token pattern is preserved

--- a/src/context_engine/memory/hooks.py
+++ b/src/context_engine/memory/hooks.py
@@ -95,9 +95,14 @@ def build_session_resume(conn: sqlite3.Connection, project: str) -> str:
         parts.append("**Recent decisions** (most-recent first):")
         for d in decisions:
             decision = _grammar_expand((d["decision"] or "").strip())
-            reason = _grammar_expand((d["reason"] or "").strip())
-            if reason and len(reason) > _RESUME_DECISION_REASON_CHARS:
-                reason = reason[:_RESUME_DECISION_REASON_CHARS] + "…"
+            # Truncate before expand so the cap operates on stored bytes,
+            # not on post-expand bytes — otherwise two reasons that stored
+            # equal length display unequal length depending on how many
+            # abbreviations expand.
+            stored_reason = (d["reason"] or "").strip()
+            if len(stored_reason) > _RESUME_DECISION_REASON_CHARS:
+                stored_reason = stored_reason[:_RESUME_DECISION_REASON_CHARS] + "…"
+            reason = _grammar_expand(stored_reason)
             tag = ""
             if d["source"] != "manual":
                 tag = f" _[{d['source']}]_"

--- a/src/context_engine/memory/migrate.py
+++ b/src/context_engine/memory/migrate.py
@@ -176,19 +176,43 @@ def _insert_decision(conn, *, session_id, decision, reason, timestamp):
     # their original ordering instead of being stamped to "now".
     epoch = int(timestamp) if timestamp is not None else int(time.time())
     iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(epoch))
+    # Mirror the live record_decision write path: pass through grammar.compress
+    # at the project default level so migrated rows land in storage at the
+    # same shape as freshly recorded ones. Without this the FTS5 index sits
+    # over a heterogeneous corpus (compressed-with-articles-dropped + raw),
+    # and `_content_key` dedup would fail across the same boundary.
+    from context_engine.memory.grammar import (
+        compress as _grammar_compress, DEFAULT_LEVEL as _GRAMMAR_LEVEL,
+    )
     conn.execute(
         "INSERT INTO decisions (session_id, decision, reason, source, "
         "created_at_epoch, created_at) VALUES (?, ?, ?, 'migrated', ?, ?)",
-        (session_id, decision, reason, epoch, iso),
+        (
+            session_id,
+            _grammar_compress(decision or "", level=_GRAMMAR_LEVEL),
+            _grammar_compress(reason or "", level=_GRAMMAR_LEVEL),
+            epoch,
+            iso,
+        ),
     )
 
 
 def _insert_code_area(conn, *, session_id, file_path, description, timestamp):
     epoch = int(timestamp) if timestamp is not None else int(time.time())
+    # description is prose; file_path is a structured token preserved by
+    # grammar.compress's tokeniser. Compressing both is safe + symmetric.
+    from context_engine.memory.grammar import (
+        compress as _grammar_compress, DEFAULT_LEVEL as _GRAMMAR_LEVEL,
+    )
     conn.execute(
         "INSERT INTO code_areas (session_id, file_path, description, source, "
         "created_at_epoch) VALUES (?, ?, ?, 'migrated', ?)",
-        (session_id, file_path, description, epoch),
+        (
+            session_id,
+            file_path,  # path is a structured token; no point compressing
+            _grammar_compress(description or "", level=_GRAMMAR_LEVEL),
+            epoch,
+        ),
     )
 
 

--- a/tests/dashboard/test_memory_endpoints.py
+++ b/tests/dashboard/test_memory_endpoints.py
@@ -162,3 +162,52 @@ def test_memory_decisions_handles_special_chars(client):
     rows = resp.json()
     assert len(rows) == 1
     assert "bge-small" in rows[0]["decision"]
+
+
+def test_memory_decisions_endpoint_expands_compressed_storage(client):
+    """The dashboard reads stored bytes that went through grammar.compress.
+    Render must expand abbreviations so users see "because" not "b/c"."""
+    c, storage = client
+    db_path = memory_db.memory_db_path(storage)
+    conn = memory_db.connect(db_path)
+    conn.execute(
+        "INSERT INTO decisions (decision, reason, source, "
+        "created_at_epoch, created_at) VALUES "
+        "('Use prod config b/c env drift', 'Avoids dev/prod mismatch', "
+        "'manual', 1700000000, '2023-11-14T22:13:20')"
+    )
+    conn.commit()
+    conn.close()
+
+    rows = c.get("/api/memory/decisions").json()
+    target = next((r for r in rows if "prod" in r["decision"]), None)
+    assert target is not None, rows
+    # b/c → because, prod → production
+    assert "because" in target["decision"]
+    assert "production" in target["decision"]
+
+
+def test_memory_session_timeline_expands_summary_and_rollup(client):
+    """rollup_summary and per-turn summary are both stored compressed;
+    timeline endpoint must run them through expand."""
+    c, storage = client
+    db_path = memory_db.memory_db_path(storage)
+    conn = memory_db.connect(db_path)
+    conn.execute(
+        "INSERT INTO sessions (id, project, started_at_epoch, started_at, "
+        "status, prompt_count, rollup_summary, rollup_summary_at_epoch) "
+        "VALUES ('s-comp', 'demo', 1700000000, '2023-11-14T22:13:20', "
+        "'completed', 1, 'Picked auth flow b/c mesh keys', 1700000300)"
+    )
+    conn.execute(
+        "INSERT INTO turn_summaries (session_id, prompt_number, summary, "
+        "tier, created_at_epoch) VALUES ('s-comp', 1, "
+        "'Discussed perf w/ team', 'extractive', 1700000200)"
+    )
+    conn.commit()
+    conn.close()
+
+    body = c.get("/api/memory/sessions/s-comp/timeline").json()
+    assert "because" in body["session"]["rollup_summary"]
+    assert "performance" in body["turns"][0]["summary"]
+    assert "with" in body["turns"][0]["summary"]

--- a/tests/memory/test_grammar.py
+++ b/tests/memory/test_grammar.py
@@ -336,3 +336,29 @@ def test_compression_ratio_meaningful_for_compressed():
 
 def test_compression_ratio_handles_empty_input():
     assert compression_ratio("", "") == 0.0
+
+
+# ── ULTRA-only fillers (added in d319e23) ──────────────────────────────────
+
+
+@pytest.mark.parametrize("filler", [
+    "also", "still", "now", "when", "while", "since",
+    "we", "you", "they", "us", "them",
+    "let", "get", "got", "take", "took",
+    "truly", "absolutely", "completely", "totally", "entirely",
+])
+def test_ultra_drops_filler_that_full_keeps(filler):
+    """Each ULTRA-only filler must be dropped at ultra and preserved at
+    full. Without this parametrised test a regression that silently
+    removes a filler from `_FILLERS_ULTRA` would only show up via the
+    aggregate inequality assertion — which would still pass.
+    """
+    text = f"the test {filler} keeps working"
+    full_out = compress(text, level="full")
+    ultra_out = compress(text, level="ultra")
+    assert filler in full_out.split(), (
+        f"{filler!r} unexpectedly dropped at full level: {full_out!r}"
+    )
+    assert filler not in ultra_out.split(), (
+        f"{filler!r} should be dropped at ultra: {ultra_out!r}"
+    )

--- a/tests/memory/test_hooks.py
+++ b/tests/memory/test_hooks.py
@@ -56,6 +56,40 @@ async def test_session_start_idempotent(hook_app, aiohttp_client):
     assert n == 1
 
 
+async def test_session_start_resume_expands_compressed_text(hook_app, aiohttp_client):
+    """Stored decisions / rollups went through grammar.compress on write.
+    The resume body must run them through expand() so the agent sees natural
+    prose ("because") rather than the storage form ("b/c"). This guards
+    against a regression where someone removes the expand call."""
+    app, conn = hook_app
+    conn.execute(
+        "INSERT INTO sessions (id, project, started_at_epoch, started_at, "
+        "ended_at_epoch, ended_at, status, rollup_summary, "
+        "rollup_summary_at_epoch) VALUES "
+        "('compr', 'demo', 1700000000, '2023-11-14T22:13:20', "
+        "1700003600, '2023-11-14T23:13:20', 'completed', "
+        "'Picked auth via JWT b/c mesh issues keys', 1700003600)"
+    )
+    conn.execute(
+        "INSERT INTO decisions (decision, reason, source, "
+        "created_at_epoch, created_at) VALUES "
+        "('Use prod config for tests', 'Avoids dev/prod drift', 'manual', "
+        "1700001000, '2023-11-14T22:30:00')"
+    )
+    conn.commit()
+
+    client = await aiohttp_client(app)
+    resp = await client.post(
+        "/hooks/SessionStart",
+        json={"session_id": "newcompr", "project": "demo"},
+    )
+    text = await resp.text()
+    # b/c → because (rollup), prod → production (decision)
+    assert "because" in text, f"expand() not applied: {text!r}"
+    assert "production" in text, f"expand() not applied to decision: {text!r}"
+    assert "b/c" not in text
+
+
 async def test_session_start_resume_with_only_decisions(hook_app, aiohttp_client):
     """Common week-1 state: decisions exist but no session has rollup yet.
     The resume must still surface the decisions section."""

--- a/tests/memory/test_mcp_recall.py
+++ b/tests/memory/test_mcp_recall.py
@@ -255,6 +255,28 @@ def test_rrf_dedupes_by_stripped_text():
     assert "use jwt — stateless" in out[0]
 
 
+def test_rrf_dedupes_across_compression_boundary():
+    """The audit case: same decision stored compressed in memory.db and
+    raw in JSON history must collapse to ONE entry. This was a real
+    production bug live-confirmed before this fix — the same decision
+    surfaced twice in `session_recall` output because `_content_key`
+    didn't normalise the article-drop difference between compressed and
+    raw forms.
+    """
+    from context_engine.integration.mcp_server import _rrf_merge
+    out = _rrf_merge(
+        # memory.db form: compressed (article dropped)
+        ["[decision src=manual|sid:abc] Adopt JWT — Mesh issues these keys"],
+        # JSON history form: raw (article intact)
+        ["[decision] Adopt the JWT — Mesh issues these keys"],
+        top=10,
+    )
+    assert len(out) == 1, (
+        f"compressed + raw forms of the same decision should collapse to "
+        f"one RRF entry, got {len(out)}: {out!r}"
+    )
+
+
 def test_humanise_relative_time():
     import time as _time
     from context_engine.integration.mcp_server import _humanise_relative_time


### PR DESCRIPTION
Post-merge wire-up audit of `main` (head `14cb373`) surfaced 8 items spanning real production bugs, UX gaps, schema↔code drift, test gaps, and one cosmetic ordering issue. All addressed in this PR.

## Items fixed

| # | Severity | What | Fix |
|---|---|---|---|
| 1 | **production-bug** | RRF dedup broken in dual-write window — same decision surfaced twice in `session_recall` (memory.db expanded vs JSON raw had different `_content_key`). **Live-confirmed.** | `_content_key` now runs through `grammar.compress(lite)` to canonicalise across the storage boundary |
| 2 | **ux-gap** | Dashboard returned raw compressed bytes — users would see `use jwt b/c mesh` instead of natural prose | `/api/memory/sessions`, `/api/memory/sessions/{id}/timeline`, `/api/memory/decisions` now apply `grammar.expand` to rollup/summary/decision/reason |
| 3 | quiet-edge | `cce sessions migrate` skipped `grammar.compress` — heterogeneous storage between manual + migrated rows | `_insert_decision` / `_insert_code_area` now apply compression to match the live write path |
| 4 | test-gap | `build_session_resume`'s expand call was tautological (existing tests seeded natural strings) | New test seeds compressed strings, asserts expanded forms appear |
| 5 | quiet-edge | 200-char reason truncation ran *after* expand — equal stored length displayed unequal | Truncate before expand so cap operates on stored bytes |
| 6 | quiet-edge | Bench level drift — `bench_recall.py` hardcoded `level="lite"` separately from source | New `DEFAULT_LEVEL` constant in `grammar.py`; imported by mcp_server, compressor, migrate, bench |
| 7 | test-gap | ULTRA-only fillers had no targeted test | +21 parametrised tests covering each new filler |
| 8 | vestigial | `tool_events.summary` column unused | Confirmed reserved-for-future-use; the audit's claimed "no aged-out test" was incorrect (test already exists from earlier PR) |

## Live verification (the production-bug case)

Recorded a new decision through `_handle_record_decision` (which compresses + dual-writes), then queried `session_recall("grammar compression")`:

**Before this PR:** decision appeared TWICE in source matches — once with `[decision src=manual|sid:...]` (memory.db form) and once with `[decision]` (JSON form, with the dropped article restored).

**After this PR:** decision appears ONCE in source matches (the richer memory.db form with provenance + recency + drill affordance survives the dedup; the JSON form is collapsed via the canonicalised content key).

## Tests

- 603/603 across the full suite (added 25 new tests across the audit fixes)
- New tests pin: cross-compression-boundary RRF dedup, dashboard expand for both decisions and timeline endpoints, SessionStart resume expand on compressed input, all 21 ULTRA-only fillers
- CI to confirm