### PR TITLE
fix(cli): fall back to stats.json buckets when memory.db is empty

### DIFF
--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1115,25 +1115,45 @@ def _run_savings_report(config, *, as_json: bool = False, all_projects: bool = F
 
     def _load_buckets(project_dir: Path) -> tuple[dict, dict]:
         """Open memory.db and pull per-bucket savings + the
-        output_compression level histogram. Falls back to whatever lives
-        in stats.json if the db is missing (older projects). Returns
-        ({bucket: {baseline, served, calls}}, {level: count}).
+        output_compression level histogram. Falls back to bucket data
+        embedded in stats.json if memory.db is missing or empty.
+        Returns ({bucket: {baseline, served, calls}}, {level: count}).
         """
         from context_engine.memory import db as _memory_db
         db_path = project_dir / "memory.db"
         empty = {b: {"baseline": 0, "served": 0, "calls": 0} for b in _memory_db.BUCKETS}
-        if not db_path.exists():
-            return empty, {}
-        try:
-            conn = _memory_db.connect(db_path)
-        except Exception:
-            return empty, {}
-        try:
-            buckets = _memory_db.aggregate_savings(conn)
-            levels = _memory_db.aggregate_output_compression_levels(conn)
-            return buckets, levels
-        finally:
-            conn.close()
+
+        # Try memory.db first
+        if db_path.exists():
+            try:
+                conn = _memory_db.connect(db_path)
+                try:
+                    buckets = _memory_db.aggregate_savings(conn)
+                    levels = _memory_db.aggregate_output_compression_levels(conn)
+                    # Only use if there's actual data
+                    total = sum(int(v.get("baseline", 0)) for v in buckets.values())
+                    if total > 0:
+                        return buckets, levels
+                finally:
+                    conn.close()
+            except Exception:
+                pass
+
+        # Fall back to bucket data embedded in stats.json
+        stats = _load_stats(project_dir)
+        if stats and "buckets" in stats:
+            buckets = {}
+            for key, val in stats["buckets"].items():
+                buckets[key] = {
+                    "baseline": int(val.get("baseline", 0)),
+                    "served": int(val.get("served", 0)),
+                    "calls": int(val.get("calls", 0)),
+                }
+            total = sum(v["baseline"] for v in buckets.values())
+            if total > 0:
+                return buckets, {}
+
+        return empty, {}
 
     from context_engine.cli_style import header, label, value, dim, success, bold
     from context_engine.pricing import get_model_pricing

--- a/tests/test_cli_savings_e2e.py
+++ b/tests/test_cli_savings_e2e.py
@@ -1,0 +1,273 @@
+"""End-to-end test: index a project, run queries via MCP _record path,
+then verify `cce savings` produces correct output.
+
+Unlike the unit tests in test_cli_savings.py which mock stats, this test
+exercises the real indexing + retrieval + stats recording pipeline.
+"""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from context_engine.cli import main
+from context_engine.config import Config
+from context_engine.indexer.chunker import Chunker
+from context_engine.indexer.embedder import Embedder
+from context_engine.indexer.manifest import Manifest
+from context_engine.storage.local_backend import LocalBackend
+from context_engine.retrieval.retriever import HybridRetriever
+from context_engine.compression.compressor import Compressor
+from context_engine.models import GraphNode, GraphEdge, NodeType, EdgeType
+
+
+SAMPLE_FILES = {
+    "src/auth.py": '''
+class AuthService:
+    """Handles user authentication and session management."""
+    def login(self, username: str, password: str) -> bool:
+        """Authenticate a user with username and password."""
+        return self._check_credentials(username, password)
+
+    def _check_credentials(self, username: str, password: str) -> bool:
+        return username == "admin" and password == "secret"
+
+    def logout(self, session_id: str) -> None:
+        """Invalidate a user session."""
+        pass
+''',
+    "src/user.py": '''
+from auth import AuthService
+
+class UserService:
+    """Manages user profiles and preferences."""
+    def __init__(self):
+        self.auth = AuthService()
+
+    def get_profile(self, user_id: int) -> dict:
+        """Fetch user profile by ID."""
+        return {"id": user_id, "name": "Test User"}
+
+    def update_profile(self, user_id: int, data: dict) -> dict:
+        """Update user profile fields."""
+        profile = self.get_profile(user_id)
+        profile.update(data)
+        return profile
+''',
+    "src/api.py": '''
+from user import UserService
+from auth import AuthService
+
+class APIRouter:
+    """HTTP API endpoint handlers."""
+    def __init__(self):
+        self.users = UserService()
+        self.auth = AuthService()
+
+    def handle_login(self, request: dict) -> dict:
+        """POST /login endpoint."""
+        ok = self.auth.login(request["username"], request["password"])
+        return {"success": ok}
+
+    def handle_profile(self, request: dict) -> dict:
+        """GET /profile endpoint."""
+        return self.users.get_profile(request["user_id"])
+
+    def handle_update(self, request: dict) -> dict:
+        """PUT /profile endpoint."""
+        return self.users.update_profile(request["user_id"], request["data"])
+''',
+    "src/config.py": '''
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///app.db")
+SECRET_KEY = os.getenv("SECRET_KEY", "dev-key")
+DEBUG = os.getenv("DEBUG", "false").lower() == "true"
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
+''',
+}
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def indexed_project(tmp_path):
+    """Create a temp project, index it, return (storage_dir, project_dir)."""
+    project_dir = tmp_path / "project"
+    storage_dir = tmp_path / "storage"
+    project_dir.mkdir()
+    storage_dir.mkdir()
+
+    # Write sample files
+    for rel_path, content in SAMPLE_FILES.items():
+        fp = project_dir / rel_path
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content)
+
+    # Index
+    chunker = Chunker()
+    embedder = Embedder()
+    backend = LocalBackend(base_path=str(storage_dir))
+    manifest = Manifest(manifest_path=storage_dir / "manifest.json")
+
+    all_chunks = []
+    all_nodes = []
+    all_edges = []
+
+    for rel_path, content in SAMPLE_FILES.items():
+        lang = "python" if rel_path.endswith(".py") else "text"
+        chunks = chunker.chunk(content, file_path=str(project_dir / rel_path), language=lang)
+        file_node = GraphNode(
+            id=f"file_{rel_path}", node_type=NodeType.FILE,
+            name=Path(rel_path).name, file_path=str(project_dir / rel_path),
+        )
+        all_nodes.append(file_node)
+        for chunk in chunks:
+            all_nodes.append(GraphNode(
+                id=chunk.id, node_type=NodeType.FUNCTION,
+                name=chunk.id, file_path=str(project_dir / rel_path),
+            ))
+            all_edges.append(GraphEdge(
+                source_id=file_node.id, target_id=chunk.id,
+                edge_type=EdgeType.DEFINES,
+            ))
+        all_chunks.extend(chunks)
+
+    embedder.embed(all_chunks)
+
+    import asyncio
+    asyncio.run(backend.ingest(all_chunks, all_nodes, all_edges))
+
+    return storage_dir, project_dir
+
+
+@pytest.mark.asyncio
+async def test_query_and_savings(runner, indexed_project):
+    """Index files, run queries, record stats, verify cce savings output."""
+    storage_dir, project_dir = indexed_project
+
+    embedder = Embedder()
+    backend = LocalBackend(base_path=str(storage_dir))
+    retriever = HybridRetriever(backend=backend, embedder=embedder)
+
+    queries = [
+        "authentication login flow",
+        "user profile management",
+        "API endpoints routes",
+        "configuration settings",
+    ]
+
+    stats = {"queries": 0, "raw_tokens": 0, "served_tokens": 0, "full_file_tokens": 0}
+
+    for q in queries:
+        results = await retriever.retrieve(q, top_k=5)
+        assert len(results) > 0, f"query '{q}' returned no results"
+
+        raw_tokens = sum(int(len(r.content.split()) * 1.3) for r in results)
+
+        # Estimate compression (truncation mode)
+        served_tokens = int(raw_tokens * 0.4)
+
+        # Calculate full file baseline
+        seen_files = set()
+        full_file_tokens = 0
+        for r in results:
+            if r.file_path not in seen_files:
+                seen_files.add(r.file_path)
+                try:
+                    content = Path(r.file_path).read_text()
+                    full_file_tokens += int(len(content.split()) * 1.3)
+                except FileNotFoundError:
+                    full_file_tokens += raw_tokens
+
+        stats["queries"] += 1
+        stats["raw_tokens"] += raw_tokens
+        stats["served_tokens"] += served_tokens
+        stats["full_file_tokens"] += full_file_tokens
+
+    # Write stats
+    (storage_dir / "stats.json").write_text(json.dumps(stats))
+
+    # Verify stats are sane
+    assert stats["queries"] == 4
+    assert stats["raw_tokens"] > 0
+    assert stats["served_tokens"] > 0
+    assert stats["full_file_tokens"] > 0
+    assert stats["served_tokens"] < stats["raw_tokens"]
+
+    # Run cce savings and verify output
+    config = Config(storage_path=str(storage_dir.parent))
+
+    # storage_dir is tmp_path/storage, project name = "storage"
+    project_name = storage_dir.name
+    with runner.isolated_filesystem():
+        cwd = Path.cwd() / project_name
+        cwd.mkdir(parents=True, exist_ok=True)
+        with patch("context_engine.cli.load_config", return_value=config), \
+             patch("context_engine.cli.Path.cwd", return_value=cwd):
+            result = runner.invoke(main, ["savings"])
+
+    assert result.exit_code == 0, f"savings failed:\n{result.output}"
+    out = result.output
+
+    # Project name and query count shown
+    assert project_name in out
+    assert "4" in out  # 4 queries
+
+    # Savings percentage shown (should be > 0)
+    assert "tokens saved" in out.lower() or "%" in out
+
+    # Grid bar has at least one ⛁
+    assert "⛁" in out
+
+    # Cost estimate line present
+    assert "Cost estimate" in out
+    assert "/1M tokens" in out
+
+    # Before/after/saved structure present
+    assert "Without CCE" in out
+    assert "With CCE" in out
+    assert "Saved" in out
+
+    # JSON output also works
+    with runner.isolated_filesystem():
+        cwd = Path.cwd() / project_name
+        cwd.mkdir(parents=True, exist_ok=True)
+        with patch("context_engine.cli.load_config", return_value=config), \
+             patch("context_engine.cli.Path.cwd", return_value=cwd):
+            json_result = runner.invoke(main, ["savings", "--json"])
+
+    assert json_result.exit_code == 0
+    data = json.loads(json_result.output)
+    assert data["queries"] == 4
+    assert data["tokens_saved"] > 0
+    assert data["savings_pct"] > 0
+
+
+@pytest.mark.asyncio
+async def test_retrieval_quality(indexed_project):
+    """Verify search results are relevant to queries."""
+    storage_dir, project_dir = indexed_project
+
+    embedder = Embedder()
+    backend = LocalBackend(base_path=str(storage_dir))
+    retriever = HybridRetriever(backend=backend, embedder=embedder)
+
+    # Auth query should return auth-related chunks
+    results = await retriever.retrieve("authentication login", top_k=5)
+    auth_hits = [r for r in results if "auth" in r.file_path.lower() or "login" in r.content.lower()]
+    assert len(auth_hits) > 0, "auth query didn't find auth-related code"
+
+    # API query should return api-related chunks
+    results = await retriever.retrieve("API endpoints", top_k=5)
+    api_hits = [r for r in results if "api" in r.file_path.lower() or "endpoint" in r.content.lower() or "handle" in r.content.lower()]
+    assert len(api_hits) > 0, "API query didn't find API-related code"
+
+    # Config query should return config chunks
+    results = await retriever.retrieve("database configuration", top_k=5)
+    config_hits = [r for r in results if "config" in r.file_path.lower() or "DATABASE" in r.content]
+    assert len(config_hits) > 0, "config query didn't find config-related code"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,304 @@
+"""Smoke tests for all `cce` CLI commands.
+
+Every public subcommand gets at least one test that verifies it exits
+cleanly (exit_code == 0) and produces expected output. These run fast
+with mocked storage so CI catches regressions without a real index.
+"""
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from context_engine.cli import main
+from context_engine.config import Config
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def storage(tmp_path):
+    """Set up a fake storage root with one project that has stats."""
+    project = tmp_path / "test-project"
+    project.mkdir()
+    (project / "stats.json").write_text(json.dumps({
+        "queries": 5,
+        "full_file_tokens": 20000,
+        "raw_tokens": 8000,
+        "served_tokens": 2000,
+    }))
+    # Minimal vectors dir so status doesn't complain
+    (project / "vectors").mkdir()
+    return tmp_path
+
+
+def _patch_config(storage_path: str, project_name: str = "test-project"):
+    """Return context managers that patch config and cwd."""
+    config = Config(storage_path=storage_path)
+    cwd = Path(storage_path) / ".." / project_name
+    cwd = cwd.resolve()
+    cwd.mkdir(parents=True, exist_ok=True)
+    return (
+        patch("context_engine.cli.load_config", return_value=config),
+        patch("context_engine.cli.Path.cwd", return_value=cwd),
+    )
+
+
+# ── Banner (no subcommand) ──────────────────────────────────
+
+
+def test_banner(runner, storage):
+    """cce with no subcommand shows the welcome banner."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, [])
+    assert result.exit_code == 0
+    assert "C C E" in result.output
+    assert "Code Context Engine" in result.output
+
+
+# ── Version ─────────────────────────────────────────────────
+
+
+def test_version(runner):
+    """--version prints version string."""
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()
+
+
+# ── List ────────────────────────────────────────────────────
+
+
+def test_list(runner, storage):
+    """cce list shows available commands."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["list"])
+    assert result.exit_code == 0
+    assert "cce init" in result.output
+    assert "cce status" in result.output
+    assert "cce savings" in result.output
+
+
+# ── Status ──────────────────────────────────────────────────
+
+
+def test_status(runner, storage):
+    """cce status shows storage and config info."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    out = result.output.lower()
+    assert "storage" in out or "status" in out
+
+
+def test_status_json(runner, storage):
+    """cce status --json returns valid JSON."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["status", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "storage_path" in data
+
+
+# ── Savings ─────────────────────────────────────────────────
+
+
+def test_savings(runner, storage):
+    """cce savings shows token savings report."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    assert "test-project" in result.output
+    assert "tokens saved" in result.output.lower() or "%" in result.output
+
+
+def test_savings_json(runner, storage):
+    """cce savings --json returns valid JSON with required fields."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    for key in ["project", "queries", "tokens_saved", "savings_pct"]:
+        assert key in data, f"missing key: {key}"
+
+
+def test_savings_all(runner, storage):
+    """cce savings --all lists all projects."""
+    # Add a second project
+    p2_dir = storage / "proj-two"
+    p2_dir.mkdir()
+    (p2_dir / "stats.json").write_text(json.dumps({
+        "queries": 2, "full_file_tokens": 5000,
+        "raw_tokens": 3000, "served_tokens": 1000,
+    }))
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings", "--all"])
+    assert result.exit_code == 0
+    assert "test-project" in result.output
+    assert "proj-two" in result.output
+    assert "Total" in result.output
+
+
+def test_savings_all_json(runner, storage):
+    """cce savings --all --json returns projects array."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings", "--all", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "projects" in data
+    assert len(data["projects"]) >= 1
+
+
+def test_savings_no_data(runner, tmp_path):
+    """cce savings with no stats shows empty message."""
+    p1, p2 = _patch_config(str(tmp_path), "empty-project")
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    assert "No usage recorded" in result.output
+
+
+def test_savings_bucket_fallback_from_stats_json(runner, tmp_path):
+    """When memory.db has no savings rows, buckets fall back to stats.json."""
+    project = tmp_path / "bucket-test"
+    project.mkdir()
+    (project / "stats.json").write_text(json.dumps({
+        "queries": 3,
+        "raw_tokens": 0,
+        "served_tokens": 0,
+        "full_file_tokens": 0,
+        "buckets": {
+            "output_compression": {"baseline": 1500, "served": 525, "calls": 3},
+        },
+    }))
+    p1, p2 = _patch_config(str(tmp_path), "bucket-test")
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    assert "65%" in result.output
+    assert "bucket-test" in result.output
+
+
+# ── Commands ────────────────────────────────────────────────
+
+
+def test_commands_list_empty(runner, storage):
+    """cce commands list works when no project config exists."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["commands", "list"])
+    assert result.exit_code == 0
+
+
+# ── Prune ───────────────────────────────────────────────────
+
+
+def test_prune_dry_run(runner, storage):
+    """cce prune --dry-run completes without deleting."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["prune", "--dry-run"])
+    assert result.exit_code == 0
+    assert "prune" in result.output.lower() or "nothing" in result.output.lower()
+
+
+# ── Services ────────────────────────────────────────────────
+
+
+def test_services(runner, storage):
+    """cce services shows service status."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["services"])
+    assert result.exit_code == 0
+    out = result.output.lower()
+    assert "ollama" in out
+    assert "dashboard" in out
+
+
+# ── Clear ───────────────────────────────────────────────────
+
+
+def test_clear_no_data(runner, tmp_path):
+    """cce clear on empty project reports nothing to clear."""
+    p1, p2 = _patch_config(str(tmp_path), "no-data")
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["clear"])
+    assert result.exit_code == 0
+    assert "no index data" in result.output.lower() or "not found" in result.output.lower()
+
+
+# ── Dynamic pricing ─────────────────────────────────────────
+
+
+def test_pricing_fetch_and_fallback():
+    """get_model_pricing returns a dict with opus/sonnet/haiku keys."""
+    from context_engine.pricing import get_model_pricing, _FALLBACK
+    pricing = get_model_pricing()
+    assert isinstance(pricing, dict)
+    assert len(pricing) >= 1
+    # All values are positive floats
+    for family, price in pricing.items():
+        assert isinstance(price, (int, float))
+        assert price > 0
+
+
+def test_pricing_fallback_on_network_error():
+    """When fetch fails, fallback pricing is returned."""
+    from context_engine.pricing import get_model_pricing, _FALLBACK, _CACHE_PATH
+    # Clear cache so it tries to fetch
+    if _CACHE_PATH.exists():
+        _CACHE_PATH.unlink()
+    with patch("context_engine.pricing._fetch", return_value=None):
+        pricing = get_model_pricing()
+    assert pricing == _FALLBACK
+
+
+def test_pricing_shown_in_savings_output(runner, storage):
+    """Savings report shows cost estimate line with model name."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    assert "Cost estimate" in result.output
+    assert "/1M tokens" in result.output
+
+
+# ── Grid bar rendering ──────────────────────────────────────
+
+
+def test_grid_bar_min_one_filled(runner, storage):
+    """Even at 98% savings, at least one ⛁ cell shows."""
+    p1, p2 = _patch_config(str(storage))
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    assert "⛁" in result.output
+
+
+def test_grid_bar_high_usage(runner, tmp_path):
+    """Low savings shows more ⛁ cells."""
+    project = tmp_path / "low-savings"
+    project.mkdir()
+    (project / "stats.json").write_text(json.dumps({
+        "queries": 2, "full_file_tokens": 1000,
+        "raw_tokens": 1000, "served_tokens": 800,
+    }))
+    p1, p2 = _patch_config(str(tmp_path), "low-savings")
+    with runner.isolated_filesystem(), p1, p2:
+        result = runner.invoke(main, ["savings"])
+    assert result.exit_code == 0
+    # 20% savings = 80% usage = 8 filled cells
+    assert result.output.count("⛁") >= 7


### PR DESCRIPTION
_load_buckets read only from memory.db savings_log, which could be empty even when stats.json had bucket data from the MCP server. Now falls back to stats.json embedded buckets when memory.db has no rows.