### PR TITLE
feat: configurable Ollama URL (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Zero-config by default. Override what you need in `~/.cce/config.yaml` or `.cont
 compression:
   level: standard          # minimal | standard | full
   output: standard         # off | lite | standard | max
+  ollama_url: http://localhost:11434   # point at a remote Ollama if desired
 
 retrieval:
   top_k: 20
@@ -302,6 +303,8 @@ retrieval:
 pricing:
   model: opus              # opus | sonnet | haiku
 ```
+
+**Remote Ollama:** If you run Ollama on another machine in your network, set `compression.ollama_url` (e.g. `http://nas.local:11434`) or export `CCE_OLLAMA_URL` — the env var wins. CCE probes the endpoint and falls back to truncation-only compression when it's unreachable, so a flaky link won't break indexing.
 
 ---
 

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import click
 
-from context_engine.config import load_config, PROJECT_CONFIG_NAME
+from context_engine.config import load_config, resolve_ollama_url, PROJECT_CONFIG_NAME
 
 
 def _configure_mcp(project_dir: Path) -> bool:
@@ -2741,7 +2741,11 @@ async def _run_serve(config) -> None:
     backend = LocalBackend(base_path=str(storage_base))
     embedder = Embedder(model_name=config.embedding_model)
     retriever = HybridRetriever(backend=backend, embedder=embedder)
-    compressor = Compressor(model=config.compression_model, cache=backend)
+    compressor = Compressor(
+        model=config.compression_model,
+        ollama_url=resolve_ollama_url(config),
+        cache=backend,
+    )
     mcp = ContextEngineMCP(
         retriever=retriever, backend=backend, compressor=compressor,
         embedder=embedder, config=config,

--- a/src/context_engine/config.py
+++ b/src/context_engine/config.py
@@ -1,4 +1,5 @@
 """Configuration loading — global + per-project with defaults."""
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -48,6 +49,10 @@ class Config:
     # Compression
     compression_level: str = "standard"
     compression_model: str = "phi3:mini"
+    # Ollama base URL for LLM-backed compression. Defaults to a local
+    # install; point at a remote host (e.g. "http://nas.local:11434")
+    # to share one Ollama across machines. CCE_OLLAMA_URL overrides this.
+    ollama_url: str = "http://localhost:11434"
 
     # Output compression
     output_compression: str = "standard"  # off | lite | standard | max
@@ -112,6 +117,7 @@ def _deep_merge(base: dict, override: dict) -> dict:
 _EXPECTED_TYPES: dict[str, type | tuple[type, ...]] = {
     "compression_level": str,
     "compression_model": str,
+    "ollama_url": str,
     "output_compression": str,
     "embedding_model": str,
     "retrieval_confidence_threshold": (int, float),
@@ -132,6 +138,7 @@ def _apply_dict_to_config(config: Config, data: dict) -> None:
     mapping = {
         ("compression", "level"): "compression_level",
         ("compression", "model"): "compression_model",
+        ("compression", "ollama_url"): "ollama_url",
         ("compression", "output"): "output_compression",
         ("embedding", "model"): "embedding_model",
         ("retrieval", "confidence_threshold"): "retrieval_confidence_threshold",
@@ -193,3 +200,14 @@ def load_config(
     merged = _deep_merge(global_data, project_data)
     _apply_dict_to_config(config, merged)
     return config
+
+
+def resolve_ollama_url(config: Config) -> str:
+    """Return the Ollama base URL with `CCE_OLLAMA_URL` env var overriding config.
+
+    Env-var precedence lets a user point a single CCE install at a different
+    Ollama (e.g. one running on another machine) without editing config files.
+    Falls back to `config.ollama_url` (default `http://localhost:11434`).
+    """
+    env = os.environ.get("CCE_OLLAMA_URL", "").strip()
+    return env or config.ollama_url

--- a/src/context_engine/serve_http.py
+++ b/src/context_engine/serve_http.py
@@ -10,7 +10,7 @@ import hmac
 import os
 from pathlib import Path
 
-from context_engine.config import load_config, PROJECT_CONFIG_NAME
+from context_engine.config import load_config, resolve_ollama_url, PROJECT_CONFIG_NAME
 from context_engine.storage.local_backend import LocalBackend
 from context_engine.indexer.embedder import Embedder
 from context_engine.compression.compressor import Compressor
@@ -192,7 +192,11 @@ def run_http_server(config=None, host: str = "127.0.0.1", port: int = 8765) -> N
 
     backend = LocalBackend(base_path=str(storage_base))
     embedder = Embedder(model_name=config.embedding_model)
-    compressor = Compressor(model=config.compression_model, cache=backend)
+    compressor = Compressor(
+        model=config.compression_model,
+        ollama_url=resolve_ollama_url(config),
+        cache=backend,
+    )
 
     api_token = os.environ.get("CCE_API_TOKEN") or None
     if host not in _LOOPBACK_HOSTS and not api_token:

--- a/src/context_engine/services.py
+++ b/src/context_engine/services.py
@@ -72,11 +72,23 @@ def _check_port_open(port: int, host: str = "127.0.0.1") -> bool:
         return s.connect_ex((host, port)) == 0
 
 
-def _ollama_running() -> bool:
-    """Check if Ollama is responding on its default port."""
+def _resolved_ollama_url() -> str:
+    """Resolve the Ollama base URL via config + CCE_OLLAMA_URL, with a safe
+    fallback so a missing/unreadable config never breaks status checks."""
+    try:
+        from context_engine.config import load_config, resolve_ollama_url
+        return resolve_ollama_url(load_config())
+    except Exception as exc:
+        log.debug("Could not resolve Ollama URL from config, using default: %s", exc)
+        return "http://localhost:11434"
+
+
+def _ollama_running(url: str | None = None) -> bool:
+    """Check if Ollama is responding. `url` defaults to the configured base URL."""
+    base = url or _resolved_ollama_url()
     try:
         import httpx
-        resp = httpx.get("http://localhost:11434/api/tags", timeout=2.0)
+        resp = httpx.get(f"{base.rstrip('/')}/api/tags", timeout=2.0)
         return resp.status_code == 200
     except Exception:
         return False
@@ -115,22 +127,39 @@ def _mcp_running() -> bool:
 # ── Public status API ─────────────────────────────────────────────────────────
 
 def get_ollama_status() -> dict:
-    running = _ollama_running()
+    url = _resolved_ollama_url()
+    running = _ollama_running(url)
     managed_pid = _read_pid("ollama")
     managed = managed_pid is not None and _process_alive(managed_pid)
 
+    # Strip scheme for compact display ("nas.local:11434" reads better than
+    # "http://nas.local:11434/" in a status table).
+    display = url.replace("https://", "").replace("http://", "").rstrip("/")
     detail = ""
     if running:
-        detail = "localhost:11434"
+        detail = display
         if not managed:
             detail += " (external)"
+    elif _is_remote_url(url):
+        # Make it obvious why CCE isn't going to start one for them.
+        detail = f"{display} (remote, unreachable)"
 
     return {
         "name": "ollama",
         "running": running,
         "managed": managed,
+        "url": url,
         "detail": detail,
     }
+
+
+def _is_remote_url(url: str) -> bool:
+    """Treat anything that doesn't point at the local machine as remote."""
+    lower = url.lower()
+    for marker in ("//localhost", "//127.0.0.1", "//[::1]", "//0.0.0.0"):
+        if marker in lower:
+            return False
+    return True
 
 
 def get_dashboard_status() -> dict:
@@ -176,7 +205,16 @@ def get_mcp_status() -> dict:
 
 def start_ollama() -> tuple[bool, str]:
     """Start ollama serve in the background. Returns (success, message)."""
-    if _ollama_running():
+    url = _resolved_ollama_url()
+    if _is_remote_url(url):
+        # Spawning a local `ollama serve` would do nothing useful when the
+        # user has configured a remote endpoint — it'd run on a port nothing
+        # in CCE talks to. Bail loudly instead of silently misbehaving.
+        return False, (
+            f"Ollama is configured to use a remote endpoint ({url}); "
+            "CCE will not start a local server. Ensure the remote is reachable."
+        )
+    if _ollama_running(url):
         return False, "Ollama is already running."
     try:
         proc = subprocess.Popen(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,10 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
 import yaml
 
-from context_engine.config import Config, load_config
+from context_engine.config import Config, load_config, resolve_ollama_url
 
 
 def test_default_config():
@@ -47,3 +48,43 @@ def test_resource_profile_auto_detect():
     config = Config()
     profile = config.detect_resource_profile()
     assert profile in ("light", "standard", "full")
+
+
+def test_ollama_url_default():
+    assert Config().ollama_url == "http://localhost:11434"
+
+
+def test_ollama_url_yaml_override(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "compression": {"ollama_url": "http://nas.local:11434"},
+    }))
+    config = load_config(global_path=config_file)
+    assert config.ollama_url == "http://nas.local:11434"
+
+
+def test_resolve_ollama_url_prefers_env_var(monkeypatch):
+    config = Config(ollama_url="http://nas.local:11434")
+    monkeypatch.setenv("CCE_OLLAMA_URL", "http://other.host:9999")
+    assert resolve_ollama_url(config) == "http://other.host:9999"
+
+
+def test_resolve_ollama_url_falls_back_to_config(monkeypatch):
+    config = Config(ollama_url="http://nas.local:11434")
+    monkeypatch.delenv("CCE_OLLAMA_URL", raising=False)
+    assert resolve_ollama_url(config) == "http://nas.local:11434"
+
+
+def test_resolve_ollama_url_ignores_blank_env_var(monkeypatch):
+    config = Config(ollama_url="http://nas.local:11434")
+    monkeypatch.setenv("CCE_OLLAMA_URL", "   ")
+    assert resolve_ollama_url(config) == "http://nas.local:11434"
+
+
+def test_ollama_url_yaml_type_validation(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "compression": {"ollama_url": 12345},
+    }))
+    with pytest.raises(ValueError, match="ollama_url"):
+        load_config(global_path=config_file)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,7 +11,10 @@ from context_engine.services import (
     _remove_pid,
     _process_alive,
     _check_port_open,
+    _is_remote_url,
     get_dashboard_status,
+    get_ollama_status,
+    start_ollama,
 )
 
 
@@ -67,3 +70,46 @@ def test_get_dashboard_status_stopped(tmp_path, monkeypatch):
     status = get_dashboard_status()
     assert status["running"] is False
     assert status["name"] == "dashboard"
+
+
+# ── Remote-URL classification + Ollama wiring ────────────────────────────────
+
+@pytest.mark.parametrize("url", [
+    "http://localhost:11434",
+    "http://127.0.0.1:11434",
+    "http://[::1]:11434",
+    "http://0.0.0.0:11434",
+    "https://localhost:11434",
+])
+def test_is_remote_url_local(url):
+    assert _is_remote_url(url) is False
+
+
+@pytest.mark.parametrize("url", [
+    "http://nas.local:11434",
+    "http://192.168.1.50:11434",
+    "https://ollama.example.com",
+])
+def test_is_remote_url_remote(url):
+    assert _is_remote_url(url) is True
+
+
+def test_get_ollama_status_reports_configured_url(tmp_path, monkeypatch):
+    monkeypatch.setattr("context_engine.services._pid_dir", lambda: tmp_path)
+    monkeypatch.setenv("CCE_OLLAMA_URL", "http://nas.local:11434")
+    status = get_ollama_status()
+    assert status["url"] == "http://nas.local:11434"
+    # Hostname must not be silently rewritten back to localhost in the
+    # human-readable detail string.
+    assert "nas.local" in status["detail"] or status["detail"] == ""
+
+
+def test_start_ollama_refuses_when_remote_configured(tmp_path, monkeypatch):
+    """Spawning a local `ollama serve` is wrong when the user has pointed
+    CCE at a remote endpoint — would run a server nothing in CCE talks to."""
+    monkeypatch.setattr("context_engine.services._pid_dir", lambda: tmp_path)
+    monkeypatch.setenv("CCE_OLLAMA_URL", "http://nas.local:11434")
+    ok, msg = start_ollama()
+    assert ok is False
+    assert "remote" in msg.lower()
+    assert "nas.local" in msg


### PR DESCRIPTION
## Summary
- Adds `compression.ollama_url` config field (default `http://localhost:11434`) and a `CCE_OLLAMA_URL` env var that overrides it.
- Wires the resolved URL through both `Compressor()` callsites — previously hardcoded to `localhost:11434`.
- Updates `services.py` so status checks, `cce services`, and `start_ollama` honor the configured URL.

Closes #22.

## Why
A user reported (#22) that they run Ollama on a Mac elsewhere in their network and want to point CCE at it. The plumbing was already in place — `OllamaClient` and `Compressor` both already accepted a `base_url` / `ollama_url` kwarg — but nothing surfaced it in config and the two `Compressor()` instantiation sites never passed it. Hence the hardcoding-to-localhost.

The graceful-degradation the user asked for is already implemented: `Compressor._is_ollama_available` polls every 30s and falls back to truncation-only compression when the endpoint is unreachable. So a flaky remote link won't break indexing — it just downgrades compression quality until the remote returns.

## Behavior

```yaml
# ~/.cce/config.yaml or .context-engine.yaml
compression:
  ollama_url: http://nas.local:11434
```

Or per-shell override:
```bash
export CCE_OLLAMA_URL=http://nas.local:11434
```

`cce services` now reports the configured host, e.g.:
```
ollama   running   nas.local:11434 (external)
```

If a remote URL is configured and unreachable, the status row shows `nas.local:11434 (remote, unreachable)` so the user knows why compression has degraded.

`cce start ollama` refuses (with a clear message) when a remote URL is configured — spawning a local daemon would do nothing useful since CCE wouldn't talk to it.

## Test plan
- [x] `tests/test_config.py` — pins default, YAML override, env-var precedence over config, blank env-var ignored, type validation rejects non-string.
- [x] `tests/test_services.py` — pins local-vs-remote URL classification, `get_ollama_status` reports configured host, `start_ollama` refuses on remote URL.
- [x] All 813 existing tests pass.
- [ ] Manual: point a real CCE install at a remote Ollama and run `cce search` — confirm LLM-backed compression triggers against the remote.