### PR TITLE
fix: detect Codex via ~/.codex and write per-project sections (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ Restart your editor. Done. Every question now hits the index instead of re-readi
 | VS Code / Copilot | `.vscode/mcp.json` | |
 | Cursor | `.cursor/mcp.json` | `.cursorrules` |
 | Gemini CLI | `.gemini/settings.json` | `GEMINI.md` |
-| OpenAI Codex | `.codex/config.toml` | |
+| OpenAI Codex | `~/.codex/config.toml` (user-global, per-project section) | |
 | OpenCode | `opencode.json` | |
 
 Multiple editors in the same project? All get configured in one command.
+
+**Codex note:** Codex CLI reads MCP servers from `~/.codex/config.toml` only — it has no per-project config. `cce init` adds one `[mcp_servers.cce-<project>-<hash>]` section per project so multiple projects coexist; `cce uninstall` removes only the section for the current project.
 
 ```
   my-project · 38 queries

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -675,6 +675,9 @@ def init(ctx: click.Context) -> None:
             continue  # already handled above
         editor = EDITORS[editor_key]
         changed = configure_mcp(project_dir, editor_key)
+        if changed is None:
+            _warn(f"MCP server skipped for {editor['name']} (config file not writable)")
+            continue
         verb = "registered" if changed else "already configured"
         _ok(f"MCP server {verb} for {editor['name']}")
         # User-scoped editors (Codex) share one config file across all

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -676,7 +676,7 @@ def init(ctx: click.Context) -> None:
         editor = EDITORS[editor_key]
         changed = configure_mcp(project_dir, editor_key)
         if changed is None:
-            _warn(f"MCP server skipped for {editor['name']} (config file not writable)")
+            _warn(f"MCP server skipped for {editor['name']} (could not read or write config file)")
             continue
         verb = "registered" if changed else "already configured"
         _ok(f"MCP server {verb} for {editor['name']}")

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -667,16 +667,23 @@ def init(ctx: click.Context) -> None:
     else:
         _ok("MCP server already configured in " + click.style(".mcp.json", fg="cyan"))
 
-    # Configure MCP for other detected editors (Cursor, VS Code, Gemini)
+    # Configure MCP for other detected editors (Cursor, VS Code, Gemini, Codex)
+    from context_engine.editors import _editor_section  # noqa: SLF001
     detected = detect_editors(project_dir)
     for editor_key in detected:
         if editor_key == "claude":
             continue  # already handled above
         editor = EDITORS[editor_key]
-        if configure_mcp(project_dir, editor_key):
-            _ok(f"MCP server registered for {editor['name']}")
-        else:
-            _ok(f"MCP server already configured for {editor['name']}")
+        changed = configure_mcp(project_dir, editor_key)
+        verb = "registered" if changed else "already configured"
+        _ok(f"MCP server {verb} for {editor['name']}")
+        # User-scoped editors (Codex) share one config file across all
+        # projects, so surface the file + per-project section so users
+        # can see what landed where (and which block to remove by hand
+        # if they ever skip `cce uninstall`).
+        if editor.get("scope") == "user":
+            section = _editor_section(editor, project_dir)
+            click.echo(_dim(f"    ~/{editor['config_path']}  →  [{section}]"))
 
     # Write instruction files for detected editors
     for file_key, info in INSTRUCTION_FILES.items():

--- a/src/context_engine/editors.py
+++ b/src/context_engine/editors.py
@@ -371,7 +371,17 @@ def _configure_toml(
         content = _strip_toml_section(content, _LEGACY_CODEX_SECTION)
         dirty = True
 
-    if marker not in content:
+    if marker in content:
+        # The section already exists, but its values may be stale (the cce
+        # binary moved between releases, args drifted, etc.). Parse the TOML
+        # and compare; if the existing block doesn't match what we'd write,
+        # rewrite it in place rather than reporting "already configured" and
+        # leaving Codex pointed at the wrong values.
+        if not _toml_section_matches(content, section, command, project_dir):
+            content = _strip_toml_section(content, section)
+            content = content.rstrip() + "\n\n" + block
+            dirty = True
+    else:
         content = content.rstrip() + "\n\n" + block
         dirty = True
 
@@ -383,6 +393,37 @@ def _configure_toml(
     except OSError:
         return None
     return True
+
+
+def _toml_section_matches(
+    content: str, section: str, command: str, project_dir: str
+) -> bool:
+    """Return True iff `[section]` in `content` already specifies the exact
+    command + serve args we would write. If a previous install left a stale
+    binary path, or the user hand-edited the args, we want to rewrite rather
+    than silently report "already configured" and leave Codex pointed at the
+    wrong values.
+
+    Section is a dotted path like ``mcp_servers.cce-myapp-a3f2``; we walk
+    the parsed dict accordingly."""
+    try:
+        parsed = tomllib.loads(content)
+    except tomllib.TOMLDecodeError:
+        # Unparseable existing TOML — let the caller rewrite to recover.
+        return False
+
+    node: object = parsed
+    for part in section.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+
+    if not isinstance(node, dict):
+        return False
+    return (
+        node.get("command") == command
+        and node.get("args") == ["serve", "--project-dir", project_dir]
+    )
 
 
 def _legacy_codex_section_matches_project(content: str, project_dir: str) -> bool:
@@ -406,9 +447,21 @@ def _legacy_codex_section_matches_project(content: str, project_dir: str) -> boo
 
 def _strip_toml_section(content: str, section: str) -> str:
     """Remove a single `[section]` block (header + body) from TOML text.
-    Body ends at the next `[` header at column zero or end of file."""
+    Body ends at the next `[` header at column zero or end of file.
+
+    User content outside the targeted block — header comments, trailing
+    comments, blank lines between unrelated sections — is preserved verbatim.
+    Only the run of blank lines that surrounded the removed block is
+    collapsed back to a single blank line so we don't leave a multi-line
+    gap. We deliberately do NOT call `.strip()` on the whole file: that
+    would silently delete leading/trailing user content (e.g. a header
+    comment at the top of `~/.codex/config.toml`).
+    """
     pattern = rf"\[{re.escape(section)}\].*?(?=\n\[|\Z)"
-    return re.sub(pattern, "", content, flags=re.DOTALL).strip() + "\n"
+    new_content = re.sub(pattern, "", content, flags=re.DOTALL)
+    # Collapse the gap left where the section used to be: 3+ consecutive
+    # newlines (i.e. 2+ blank lines) → 2 newlines (1 blank line).
+    return re.sub(r"\n{3,}", "\n\n", new_content)
 
 
 def remove_mcp(project_dir: Path, editor_key: str) -> str | None:
@@ -476,10 +529,15 @@ def _remove_toml(config_path: Path, display_path: str, *, section: str) -> str |
     if marker not in content:
         return None
 
-    new_content = _strip_toml_section(content, section).strip()
+    new_content = _strip_toml_section(content, section)
+    # Use a whitespace check for "is the file effectively empty?" without
+    # mutating new_content — preserving any user comments/whitespace that
+    # were in the original file outside the removed section.
     try:
-        if new_content:
-            atomic_write_text(config_path, new_content + "\n")
+        if new_content.strip():
+            if not new_content.endswith("\n"):
+                new_content += "\n"
+            atomic_write_text(config_path, new_content)
             return f"Removed [{section}] from {display_path}"
         else:
             config_path.unlink()

--- a/src/context_engine/editors.py
+++ b/src/context_engine/editors.py
@@ -3,10 +3,23 @@
 Detects installed editors and writes MCP server config in each editor's
 format. Supports Claude Code, VS Code/Copilot, Cursor, Gemini CLI,
 OpenAI Codex CLI, and OpenCode.
+
+Two scopes exist for an editor's config:
+  - "project" (default): config_path / detect markers resolve under the
+    project directory. Each project gets its own config file.
+  - "user": config_path / detect markers resolve under the user's home
+    directory. One file is shared across all projects, so per-project
+    isolation is achieved via a project-derived TOML/JSON section name
+    rendered from the editor's `section_template`.
+
+Codex CLI is the only "user" scope today — it reads MCP servers from
+~/.codex/config.toml exclusively, not from per-project files.
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from pathlib import Path
 
 from context_engine.utils import atomic_write_text, resolve_cce_binary
@@ -14,6 +27,8 @@ from context_engine.utils import atomic_write_text, resolve_cce_binary
 
 # ── Editor definitions ────────────────────────────────────────────────
 # format: "json" (default) or "toml" for Codex
+# scope:  "project" (default) or "user" — controls where config_path /
+#         detect markers are resolved from. See module docstring.
 
 EDITORS: dict[str, dict] = {
     "claude": {
@@ -46,8 +61,15 @@ EDITORS: dict[str, dict] = {
     },
     "codex": {
         "name": "OpenAI Codex",
+        "scope": "user",
+        # Resolved as ~/.codex/config.toml — Codex CLI reads MCP servers
+        # from this user-global file only, never from project-local TOML.
         "config_path": ".codex/config.toml",
         "format": "toml",
+        # One section per project. The slug is derived from the project's
+        # absolute path so two projects with the same basename can coexist
+        # without overwriting each other.
+        "section_template": "mcp_servers.cce-{slug}",
         "detect": [".codex"],
     },
     "opencode": {
@@ -106,35 +128,120 @@ INSTRUCTION_FILES: dict[str, dict] = {
 }
 
 
+# ── Scope + slug helpers ──────────────────────────────────────────────
+
+def _scope_root(editor: dict, project_dir: Path) -> Path:
+    """Return the directory under which `config_path` and `detect` markers
+    are resolved for this editor — project_dir for project-scoped editors
+    (the default) or the user's home for user-scoped editors (Codex)."""
+    return Path.home() if editor.get("scope") == "user" else project_dir
+
+
+def _resolved_config_path(editor: dict, project_dir: Path) -> Path:
+    return _scope_root(editor, project_dir) / editor["config_path"]
+
+
+def _project_slug(project_dir: Path) -> str:
+    """Stable per-directory slug used as the section name for user-scoped
+    editor configs. `cce-<basename>-<6-hex>` so two projects sharing a
+    basename ("api", "web", "frontend") get distinct sections instead of
+    silently overwriting each other in ~/.codex/config.toml.
+
+    Symlinks are resolved before hashing so two paths pointing at the
+    same on-disk directory map to the same slug (idempotent re-runs).
+    """
+    resolved = project_dir.resolve()
+    abs_path = str(resolved)
+    h = hashlib.sha256(abs_path.encode()).hexdigest()[:6]
+    # TOML bare-key chars are A-Za-z0-9_- ; replace anything else (spaces,
+    # unicode, punctuation) with `-` so the rendered section is always a
+    # syntactically valid bare key. Empty basename (root dir or trailing
+    # slash) falls back to "project" so the slug is never just "-a3f2".
+    # Use the resolved basename so symlink-vs-real-path produces the same
+    # slug — otherwise the hash would match but the basename would differ.
+    safe = "".join(c if c.isalnum() or c in "-_" else "-" for c in resolved.name)
+    return f"{safe or 'project'}-{h}"
+
+
+def _editor_section(editor: dict, project_dir: Path) -> str | None:
+    """Render the per-project section name from the editor's template, or
+    None if the editor uses a single hardcoded section (no per-project
+    naming). TOML editors must declare a section_template — they have no
+    other way to disambiguate projects sharing one user-global file."""
+    tmpl = editor.get("section_template")
+    if tmpl is None:
+        if editor.get("format") == "toml":
+            raise ValueError(
+                f"editor {editor.get('name')!r} uses TOML format but has no "
+                "section_template; per-project section names are required for "
+                "TOML editors so multiple projects don't clash in one file."
+            )
+        return None
+    return tmpl.format(slug=_project_slug(project_dir))
+
+
+def _toml_quote(s: str) -> str:
+    """Escape a string for use inside a double-quoted TOML basic string.
+
+    Without this, paths containing backslashes (Windows: ``C:\\Users\\foo``)
+    produce invalid TOML — `\\U` starts a Unicode escape that needs 8 hex
+    digits, so a Windows path written verbatim into a `"..."` value parses
+    as garbage. Escape order matters: backslashes first, then quotes.
+    """
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
 # ── Public API ────────────────────────────────────────────────────────
 
 def detect_editors(project_dir: Path) -> list[str]:
-    """Return list of editor keys detected in the project directory."""
+    """Return list of editor keys detected for this project. Markers are
+    looked up under each editor's scope root (project dir or home dir)."""
     found = []
     for key, editor in EDITORS.items():
+        root = _scope_root(editor, project_dir)
         for marker in editor["detect"]:
-            if (project_dir / marker).exists():
+            if (root / marker).exists():
                 found.append(key)
                 break
     return found
 
 
-def _codex_toml_block(command: str, project_dir: str) -> str:
-    """Generate the TOML block for Codex CLI's config.toml."""
-    args_toml = ", ".join(f'"{a}"' for a in ["serve", "--project-dir", project_dir])
-    return f'[mcp_servers.context-engine]\ncommand = "{command}"\nargs = [{args_toml}]\n'
+def _codex_toml_block(command: str, project_dir: str, *, section: str) -> str:
+    """Generate one TOML mcp_servers block. Section is the full dotted key
+    rendered from the editor's section_template (e.g. `mcp_servers.cce-myapp-a3f2`).
+    Both `command` and `project_dir` are TOML-escaped — necessary for
+    Windows paths with backslashes."""
+    cmd = _toml_quote(command)
+    proj = _toml_quote(project_dir)
+    args_toml = f'"serve", "--project-dir", "{proj}"'
+    return f'[{section}]\ncommand = "{cmd}"\nargs = [{args_toml}]\n'
 
 
 def configure_mcp(project_dir: Path, editor_key: str) -> bool:
-    """Write MCP config for a specific editor. Returns True if changed."""
+    """Write MCP config for a specific editor. Returns True if changed.
+
+    Scope-aware: user-scoped editors (Codex) write to a single user-global
+    file with a per-project section name; project-scoped editors keep their
+    existing per-project file behavior.
+    """
     editor = EDITORS[editor_key]
-    config_path = project_dir / editor["config_path"]
+    config_path = _resolved_config_path(editor, project_dir)
     command = resolve_cce_binary()
 
-    config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Defensive: e.g., ~/.codex exists but is a regular file (antivirus
+        # quarantine, manual user weirdness) — that surfaces as
+        # FileExistsError on macOS/Linux and NotADirectoryError on Windows.
+        # PermissionError can also fire for read-only homes. None of these
+        # should bring down the whole `cce init`; treat the editor as not
+        # configurable and move on.
+        return False
 
     if editor.get("format") == "toml":
-        return _configure_toml(config_path, command, str(project_dir))
+        section = _editor_section(editor, project_dir)
+        return _configure_toml(config_path, command, str(project_dir), section=section)
 
     if editor.get("format") == "opencode":
         return _configure_opencode(config_path, command, str(project_dir))
@@ -211,25 +318,73 @@ def _strip_jsonc_comments(text: str) -> str:
     return re.sub(r'//.*?$', '', text, flags=re.MULTILINE)
 
 
-def _configure_toml(config_path: Path, command: str, project_dir: str) -> bool:
-    """Add CCE to a TOML config file (Codex). Returns True if changed."""
-    block = _codex_toml_block(command, project_dir)
-    marker = "[mcp_servers.context-engine]"
+_LEGACY_CODEX_SECTION = "mcp_servers.context-engine"
 
-    if config_path.exists():
-        content = config_path.read_text()
-        if marker in content:
-            return False  # already configured
-        config_path.write_text(content.rstrip() + "\n\n" + block)
-    else:
-        config_path.write_text(block)
+
+def _configure_toml(
+    config_path: Path,
+    command: str,
+    project_dir: str,
+    *,
+    section: str,
+) -> bool:
+    """Add a per-project CCE block to a TOML config file. Returns True if changed.
+
+    Idempotent: if a block with the same section already exists, returns
+    False without rewriting. If the legacy single-block form (the
+    pre-multi-project `[mcp_servers.context-engine]`) is present and points
+    at this same project, it is replaced in place by the new per-project
+    section name — a one-shot migration so anyone who hit the previous
+    broken project-local code path doesn't end up with two stale entries.
+    """
+    block = _codex_toml_block(command, project_dir, section=section)
+    marker = f"[{section}]"
+    legacy_marker = f"[{_LEGACY_CODEX_SECTION}]"
+
+    if not config_path.exists():
+        atomic_write_text(config_path, block)
+        return True
+
+    original = config_path.read_text()
+    content = original
+    dirty = False
+
+    # Legacy migration: drop the old hardcoded `[mcp_servers.context-engine]`
+    # block if present. The per-project section replaces it — keeping both
+    # would leave a stale entry pointing at whatever project last ran the
+    # broken pre-fix code path.
+    if legacy_marker in content:
+        content = _strip_toml_section(content, _LEGACY_CODEX_SECTION)
+        dirty = True
+
+    if marker not in content:
+        content = content.rstrip() + "\n\n" + block
+        dirty = True
+
+    if not dirty:
+        return False
+
+    atomic_write_text(config_path, content if content.endswith("\n") else content + "\n")
     return True
 
 
+def _strip_toml_section(content: str, section: str) -> str:
+    """Remove a single `[section]` block (header + body) from TOML text.
+    Body ends at the next `[` header at column zero or end of file."""
+    pattern = rf"\[{re.escape(section)}\].*?(?=\n\[|\Z)"
+    return re.sub(pattern, "", content, flags=re.DOTALL).strip() + "\n"
+
+
 def remove_mcp(project_dir: Path, editor_key: str) -> str | None:
-    """Remove CCE from an editor's MCP config. Returns status message or None."""
+    """Remove CCE from an editor's MCP config. Returns status message or None.
+
+    Symmetrical with `configure_mcp`: only this project's footprint is
+    removed. For user-scoped editors (Codex), only the per-project section
+    derived from `project_dir` is deleted — other projects' sections in
+    the same user-global file are left intact.
+    """
     editor = EDITORS[editor_key]
-    config_path = project_dir / editor["config_path"]
+    config_path = _resolved_config_path(editor, project_dir)
 
     # OpenCode may use .jsonc instead of .json
     if editor.get("format") == "opencode":
@@ -241,7 +396,15 @@ def remove_mcp(project_dir: Path, editor_key: str) -> str | None:
         return None
 
     if editor.get("format") == "toml":
-        return _remove_toml(config_path, editor["config_path"])
+        section = _editor_section(editor, project_dir)
+        # Display path keeps `~` for user-scoped editors so the message
+        # reflects what the user actually has on disk (~/.codex/config.toml
+        # is more recognisable than /Users/foo/.codex/config.toml).
+        if editor.get("scope") == "user":
+            display = "~/" + editor["config_path"]
+        else:
+            display = editor["config_path"]
+        return _remove_toml(config_path, display, section=section)
 
     servers_key = editor["servers_key"]
     try:
@@ -260,20 +423,23 @@ def remove_mcp(project_dir: Path, editor_key: str) -> str | None:
         return None
 
 
-def _remove_toml(config_path: Path, display_path: str) -> str | None:
-    """Remove CCE block from a TOML config file."""
-    import re
+def _remove_toml(config_path: Path, display_path: str, *, section: str) -> str | None:
+    """Remove a single CCE-managed section from a TOML config file. Returns
+    a human-readable status message or None if there was nothing to remove.
+
+    Only the named section is touched; other CCE sections (other projects)
+    and unrelated user content are preserved. Section name is regex-escaped
+    so it can never accidentally match a longer section that shares a prefix
+    (e.g. removing `cce-api` won't touch `cce-api-staging`)."""
     content = config_path.read_text()
-    marker = "[mcp_servers.context-engine]"
+    marker = f"[{section}]"
     if marker not in content:
         return None
 
-    # Remove the [mcp_servers.context-engine] block (until next section header or EOF)
-    pattern = r"\[mcp_servers\.context-engine\].*?(?=\n\[|$)"
-    new_content = re.sub(pattern, "", content, flags=re.DOTALL).strip()
+    new_content = _strip_toml_section(content, section).strip()
     if new_content:
-        config_path.write_text(new_content + "\n")
-        return f"Removed context-engine from {display_path}"
+        atomic_write_text(config_path, new_content + "\n")
+        return f"Removed [{section}] from {display_path}"
     else:
         config_path.unlink()
         return f"Removed {display_path}"

--- a/src/context_engine/editors.py
+++ b/src/context_engine/editors.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import tomllib
 from pathlib import Path
 
 from context_engine.utils import atomic_write_text, resolve_cce_binary
@@ -143,7 +144,7 @@ def _resolved_config_path(editor: dict, project_dir: Path) -> Path:
 
 def _project_slug(project_dir: Path) -> str:
     """Stable per-directory slug used as the section name for user-scoped
-    editor configs. `cce-<basename>-<6-hex>` so two projects sharing a
+    editor configs. `<basename>-<6-hex>` so two projects sharing a
     basename ("api", "web", "frontend") get distinct sections instead of
     silently overwriting each other in ~/.codex/config.toml.
 
@@ -153,13 +154,17 @@ def _project_slug(project_dir: Path) -> str:
     resolved = project_dir.resolve()
     abs_path = str(resolved)
     h = hashlib.sha256(abs_path.encode()).hexdigest()[:6]
-    # TOML bare-key chars are A-Za-z0-9_- ; replace anything else (spaces,
-    # unicode, punctuation) with `-` so the rendered section is always a
-    # syntactically valid bare key. Empty basename (root dir or trailing
-    # slash) falls back to "project" so the slug is never just "-a3f2".
+    # TOML bare-key chars here are restricted to ASCII A-Za-z0-9_-; replace
+    # anything else (spaces, unicode, punctuation) with `-` so the rendered
+    # section is always a syntactically valid bare key. Empty basename (root
+    # dir or trailing slash) falls back to "project" so the slug is never
+    # just "-a3f2".
     # Use the resolved basename so symlink-vs-real-path produces the same
     # slug — otherwise the hash would match but the basename would differ.
-    safe = "".join(c if c.isalnum() or c in "-_" else "-" for c in resolved.name)
+    safe = "".join(
+        c if (c.isascii() and (c.isalnum() or c in "-_")) else "-"
+        for c in resolved.name
+    )
     return f"{safe or 'project'}-{h}"
 
 
@@ -217,8 +222,11 @@ def _codex_toml_block(command: str, project_dir: str, *, section: str) -> str:
     return f'[{section}]\ncommand = "{cmd}"\nargs = [{args_toml}]\n'
 
 
-def configure_mcp(project_dir: Path, editor_key: str) -> bool:
-    """Write MCP config for a specific editor. Returns True if changed.
+def configure_mcp(project_dir: Path, editor_key: str) -> bool | None:
+    """Write MCP config for a specific editor.
+
+    Returns True if changed, False if already configured, or None if the
+    config was skipped because the target file could not be read or written.
 
     Scope-aware: user-scoped editors (Codex) write to a single user-global
     file with a per-project section name; project-scoped editors keep their
@@ -237,7 +245,7 @@ def configure_mcp(project_dir: Path, editor_key: str) -> bool:
         # PermissionError can also fire for read-only homes. None of these
         # should bring down the whole `cce init`; treat the editor as not
         # configurable and move on.
-        return False
+        return None
 
     if editor.get("format") == "toml":
         section = _editor_section(editor, project_dir)
@@ -327,8 +335,11 @@ def _configure_toml(
     project_dir: str,
     *,
     section: str,
-) -> bool:
-    """Add a per-project CCE block to a TOML config file. Returns True if changed.
+) -> bool | None:
+    """Add a per-project CCE block to a TOML config file.
+
+    Returns True if changed, False if already configured, or None if the
+    config could not be read or written.
 
     Idempotent: if a block with the same section already exists, returns
     False without rewriting. If the legacy single-block form (the
@@ -341,19 +352,22 @@ def _configure_toml(
     marker = f"[{section}]"
     legacy_marker = f"[{_LEGACY_CODEX_SECTION}]"
 
-    if not config_path.exists():
-        atomic_write_text(config_path, block)
-        return True
+    try:
+        if not config_path.exists():
+            atomic_write_text(config_path, block)
+            return True
 
-    original = config_path.read_text()
+        original = config_path.read_text()
+    except OSError:
+        return None
+
     content = original
     dirty = False
 
     # Legacy migration: drop the old hardcoded `[mcp_servers.context-engine]`
-    # block if present. The per-project section replaces it — keeping both
-    # would leave a stale entry pointing at whatever project last ran the
-    # broken pre-fix code path.
-    if legacy_marker in content:
+    # block only when it points at this project. Preserve unrelated or
+    # user-managed legacy sections rather than guessing ownership.
+    if legacy_marker in content and _legacy_codex_section_matches_project(content, project_dir):
         content = _strip_toml_section(content, _LEGACY_CODEX_SECTION)
         dirty = True
 
@@ -364,8 +378,30 @@ def _configure_toml(
     if not dirty:
         return False
 
-    atomic_write_text(config_path, content if content.endswith("\n") else content + "\n")
+    try:
+        atomic_write_text(config_path, content if content.endswith("\n") else content + "\n")
+    except OSError:
+        return None
     return True
+
+
+def _legacy_codex_section_matches_project(content: str, project_dir: str) -> bool:
+    """Return True when the legacy Codex block targets this project."""
+    try:
+        parsed = tomllib.loads(content)
+    except tomllib.TOMLDecodeError:
+        return False
+
+    legacy = parsed.get("mcp_servers", {}).get("context-engine")
+    if not isinstance(legacy, dict):
+        return False
+
+    args = legacy.get("args")
+    return (
+        isinstance(args, list)
+        and len(args) >= 3
+        and args[-2:] == ["--project-dir", project_dir]
+    )
 
 
 def _strip_toml_section(content: str, section: str) -> str:
@@ -431,18 +467,25 @@ def _remove_toml(config_path: Path, display_path: str, *, section: str) -> str |
     and unrelated user content are preserved. Section name is regex-escaped
     so it can never accidentally match a longer section that shares a prefix
     (e.g. removing `cce-api` won't touch `cce-api-staging`)."""
-    content = config_path.read_text()
+    try:
+        content = config_path.read_text()
+    except OSError:
+        return None
+
     marker = f"[{section}]"
     if marker not in content:
         return None
 
     new_content = _strip_toml_section(content, section).strip()
-    if new_content:
-        atomic_write_text(config_path, new_content + "\n")
-        return f"Removed [{section}] from {display_path}"
-    else:
-        config_path.unlink()
-        return f"Removed {display_path}"
+    try:
+        if new_content:
+            atomic_write_text(config_path, new_content + "\n")
+            return f"Removed [{section}] from {display_path}"
+        else:
+            config_path.unlink()
+            return f"Removed {display_path}"
+    except OSError:
+        return None
 
 
 def write_instruction_file(project_dir: Path, file_key: str) -> bool:

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -1,0 +1,336 @@
+"""Tests for OpenAI Codex MCP configuration.
+
+Codex CLI's `mcp_servers` config is read from ~/.codex/config.toml only
+(user-global, not project-local). These tests pin the user-scope behavior:
+detection, per-project section names, idempotency, multi-project
+coexistence, legacy migration, and Windows-path TOML escaping.
+"""
+from __future__ import annotations
+
+import tomllib
+from unittest.mock import patch
+
+import pytest
+
+from context_engine.editors import (
+    EDITORS,
+    _project_slug,
+    _toml_quote,
+    configure_mcp,
+    detect_editors,
+    remove_mcp,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect Path.home() to a temp dir so tests never touch the real
+    ~/.codex/config.toml. HOME is what pathlib reads on POSIX; USERPROFILE
+    on Windows — set both so the tests run identically on either."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """A separate project directory, distinct from the fake home, so the
+    tests can prove writes land in ~/.codex/ rather than <project>/.codex/."""
+    p = tmp_path / "project"
+    p.mkdir()
+    return p
+
+
+# ── Schema sanity ────────────────────────────────────────────────────────────
+
+def test_codex_editor_is_user_scoped():
+    """Regression: if someone removes scope=user from the EDITORS entry, all
+    the user-global tests below would still pass against a project-local
+    write — because the project happens to look like a home dir to the
+    code. Pin the schema invariant separately."""
+    assert EDITORS["codex"]["scope"] == "user"
+    assert EDITORS["codex"]["section_template"] == "mcp_servers.cce-{slug}"
+
+
+# ── Slug computation ─────────────────────────────────────────────────────────
+
+def test_slug_is_deterministic_per_path(tmp_path):
+    p = tmp_path / "myapp"
+    p.mkdir()
+    assert _project_slug(p) == _project_slug(p)
+
+
+def test_slug_differs_for_same_basename_in_different_paths(tmp_path):
+    """Two projects both named "api" must get distinct slugs — otherwise
+    configuring one in Codex would silently overwrite the other in the
+    shared ~/.codex/config.toml."""
+    a = tmp_path / "a" / "api"
+    b = tmp_path / "b" / "api"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    assert _project_slug(a) != _project_slug(b)
+
+
+def test_slug_resolves_symlinks(tmp_path):
+    """Two paths pointing at the same on-disk directory (one via symlink)
+    should produce the same slug — so re-running cce init via a symlinked
+    path is idempotent rather than creating a duplicate Codex section."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert _project_slug(real) == _project_slug(link)
+
+
+def test_slug_sanitizes_basename(tmp_path):
+    """Spaces and unicode characters are not valid in TOML bare keys —
+    if the slug isn't sanitized, the rendered section header is invalid TOML."""
+    weird = tmp_path / "my project (v2)"
+    weird.mkdir()
+    slug = _project_slug(weird)
+    assert all(c.isalnum() or c in "-_" for c in slug)
+
+
+def test_slug_falls_back_when_basename_empty(tmp_path):
+    """Edge case: a path that resolves to a directory with an empty name
+    (root, etc.) should still produce a usable slug, not just `-a3f2`."""
+    # Construct a real directory whose `.name` is empty by using `.` semantics
+    # — actually Path("/").name is "" which is the case we want to exercise.
+    from pathlib import Path
+    slug = _project_slug(Path("/"))
+    assert slug.startswith("project-")
+
+
+# ── TOML escaping ────────────────────────────────────────────────────────────
+
+def test_toml_quote_escapes_backslashes_and_quotes():
+    assert _toml_quote(r"C:\Users\foo") == r"C:\\Users\\foo"
+    assert _toml_quote('say "hi"') == r'say \"hi\"'
+    assert _toml_quote("plain") == "plain"
+
+
+# ── Detection ────────────────────────────────────────────────────────────────
+
+def test_detect_codex_when_home_codex_dir_exists(fake_home, project_dir):
+    """User has Codex installed (~/.codex exists) — detection should fire
+    even though the project has no .codex/ marker."""
+    (fake_home / ".codex").mkdir()
+    detected = detect_editors(project_dir)
+    assert "codex" in detected
+
+
+def test_no_codex_detection_when_home_codex_absent(fake_home, project_dir):
+    """User does not have Codex installed — detection must NOT fire from a
+    project-local .codex/ directory (that's the bug from issue #24 in
+    reverse: we shouldn't accidentally re-introduce project-local detection)."""
+    (project_dir / ".codex").mkdir()
+    assert "codex" not in detect_editors(project_dir)
+
+
+# ── Configure: writes to ~/.codex/config.toml ────────────────────────────────
+
+def test_configure_writes_to_user_global_codex_config(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        changed = configure_mcp(project_dir, "codex")
+    assert changed is True
+    user_config = fake_home / ".codex" / "config.toml"
+    assert user_config.exists()
+    # Project-local file must not be created — that was the issue #24 bug.
+    assert not (project_dir / ".codex" / "config.toml").exists()
+
+
+def test_configure_writes_per_project_section_name(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    content = (fake_home / ".codex" / "config.toml").read_text()
+    expected_section = f"[mcp_servers.cce-{_project_slug(project_dir)}]"
+    assert expected_section in content
+    # Critically NOT the legacy hardcoded form.
+    assert "[mcp_servers.context-engine]" not in content
+
+
+def test_configure_creates_codex_dir_if_missing(fake_home, project_dir):
+    """User runs `cce init` before ever launching Codex — ~/.codex doesn't
+    exist yet (so detection wouldn't fire), but if a caller invokes
+    `configure_mcp("codex")` directly the dir should still be created
+    rather than crashing on a missing parent."""
+    assert not (fake_home / ".codex").exists()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    assert (fake_home / ".codex" / "config.toml").exists()
+
+
+# ── TOML output is parse-valid ───────────────────────────────────────────────
+
+def test_generated_toml_parses_with_tomllib(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    content = (fake_home / ".codex" / "config.toml").read_text()
+    # Must round-trip through a real TOML parser, not just substring assertions.
+    parsed = tomllib.loads(content)
+    section_key = f"cce-{_project_slug(project_dir)}"
+    assert section_key in parsed["mcp_servers"]
+    entry = parsed["mcp_servers"][section_key]
+    assert entry["command"] == "/usr/bin/cce"
+    assert entry["args"] == ["serve", "--project-dir", str(project_dir)]
+
+
+def test_generated_toml_handles_windows_style_path(fake_home):
+    """Regression for Copilot's PR #20 review: Windows paths with
+    backslashes interpolated raw into double-quoted TOML produce invalid
+    output (`\\U` is a Unicode escape requiring 8 hex digits). The escape
+    layer in `_codex_toml_block` must make this round-trip cleanly."""
+    from context_engine.editors import _codex_toml_block
+    block = _codex_toml_block(
+        command=r"C:\Program Files\cce\cce.exe",
+        project_dir=r"C:\Users\foo\my project",
+        section="mcp_servers.cce-myproject-a3f2b1",
+    )
+    parsed = tomllib.loads(block)
+    entry = parsed["mcp_servers"]["cce-myproject-a3f2b1"]
+    assert entry["command"] == r"C:\Program Files\cce\cce.exe"
+    assert entry["args"][2] == r"C:\Users\foo\my project"
+
+
+# ── Idempotency + multi-project ──────────────────────────────────────────────
+
+def test_configure_is_idempotent(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        first = configure_mcp(project_dir, "codex")
+        second = configure_mcp(project_dir, "codex")
+    assert first is True
+    assert second is False  # second call must report "no change"
+    content = (fake_home / ".codex" / "config.toml").read_text()
+    # Section must appear exactly once.
+    section = f"[mcp_servers.cce-{_project_slug(project_dir)}]"
+    assert content.count(section) == 1
+
+
+def test_multiple_projects_coexist_in_codex_config(fake_home, tmp_path):
+    """Configuring two distinct projects should leave both registered in
+    ~/.codex/config.toml — not have the second silently overwrite the first."""
+    (fake_home / ".codex").mkdir()
+    proj_a = tmp_path / "alpha"
+    proj_b = tmp_path / "beta"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(proj_a, "codex")
+        configure_mcp(proj_b, "codex")
+    parsed = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+    keys = list(parsed["mcp_servers"].keys())
+    assert any(k.startswith("cce-alpha-") for k in keys)
+    assert any(k.startswith("cce-beta-") for k in keys)
+
+
+def test_configure_preserves_unrelated_user_config(fake_home, project_dir):
+    """User has their own [mcp_servers.something-else] block in
+    ~/.codex/config.toml — adding the CCE block must not touch it."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text(
+        '[mcp_servers.linear]\n'
+        'command = "linear-mcp"\n'
+        'args = ["--workspace", "team"]\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    parsed = tomllib.loads(user_config.read_text())
+    assert parsed["mcp_servers"]["linear"]["command"] == "linear-mcp"
+    assert f"cce-{_project_slug(project_dir)}" in parsed["mcp_servers"]
+
+
+# ── Legacy migration ─────────────────────────────────────────────────────────
+
+def test_legacy_section_is_migrated_to_per_project(fake_home, project_dir):
+    """Old code wrote [mcp_servers.context-engine] (hardcoded section). On
+    first run after the fix, that legacy block should be retired in favor
+    of the per-project section — keeping both would leave a stale entry."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text(
+        '[mcp_servers.context-engine]\n'
+        'command = "/old/cce"\n'
+        'args = ["serve", "--project-dir", "/old/path"]\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    content = user_config.read_text()
+    assert "[mcp_servers.context-engine]" not in content
+    assert f"[mcp_servers.cce-{_project_slug(project_dir)}]" in content
+
+
+# ── Removal: symmetrical, scoped to this project ─────────────────────────────
+
+def test_remove_deletes_only_this_projects_section(fake_home, tmp_path):
+    """`cce uninstall` in project A must NOT remove project B's CCE section
+    from ~/.codex/config.toml — they share the file but should be
+    independently managed."""
+    (fake_home / ".codex").mkdir()
+    proj_a = tmp_path / "alpha"
+    proj_b = tmp_path / "beta"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(proj_a, "codex")
+        configure_mcp(proj_b, "codex")
+        msg = remove_mcp(proj_a, "codex")
+    assert msg is not None
+    parsed = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+    keys = list(parsed["mcp_servers"].keys())
+    assert not any(k.startswith("cce-alpha-") for k in keys), keys
+    assert any(k.startswith("cce-beta-") for k in keys), keys
+
+
+def test_remove_preserves_unrelated_user_sections(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text(
+        '[mcp_servers.linear]\n'
+        'command = "linear-mcp"\n'
+        'args = []\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+        remove_mcp(project_dir, "codex")
+    parsed = tomllib.loads(user_config.read_text())
+    assert parsed["mcp_servers"]["linear"]["command"] == "linear-mcp"
+    assert "cce-" not in str(parsed["mcp_servers"].keys())
+
+
+def test_remove_returns_none_when_section_absent(fake_home, project_dir):
+    """If this project was never registered, remove must be a clean no-op
+    — not raise, not emit a misleading 'Removed' message."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text('[mcp_servers.linear]\ncommand = "x"\nargs = []\n')
+    msg = remove_mcp(project_dir, "codex")
+    assert msg is None
+
+
+def test_remove_deletes_file_when_last_section_removed(fake_home, project_dir):
+    """If the file ends up empty after removing this project's section,
+    delete it — we own the file iff we created it (no other entries)."""
+    (fake_home / ".codex").mkdir()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+        remove_mcp(project_dir, "codex")
+    assert not (fake_home / ".codex" / "config.toml").exists()
+
+
+# ── Defensive: weird filesystem state ────────────────────────────────────────
+
+def test_configure_does_not_crash_when_codex_path_is_a_file(fake_home, project_dir):
+    """If ~/.codex exists as a regular file (antivirus quarantine, user
+    weirdness), configure_mcp must return False rather than blowing up
+    the entire `cce init`."""
+    (fake_home / ".codex").write_text("not a directory")
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        result = configure_mcp(project_dir, "codex")
+    assert result is False

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -87,10 +87,11 @@ def test_slug_resolves_symlinks(tmp_path):
 def test_slug_sanitizes_basename(tmp_path):
     """Spaces and unicode characters are not valid in TOML bare keys —
     if the slug isn't sanitized, the rendered section header is invalid TOML."""
-    weird = tmp_path / "my project (v2)"
+    weird = tmp_path / "my café project (v2)"
     weird.mkdir()
     slug = _project_slug(weird)
-    assert all(c.isalnum() or c in "-_" for c in slug)
+    assert all(c.isascii() and (c.isalnum() or c in "-_") for c in slug)
+    assert "é" not in slug
 
 
 def test_slug_falls_back_when_basename_empty(tmp_path):
@@ -251,7 +252,24 @@ def test_configure_preserves_unrelated_user_config(fake_home, project_dir):
 def test_legacy_section_is_migrated_to_per_project(fake_home, project_dir):
     """Old code wrote [mcp_servers.context-engine] (hardcoded section). On
     first run after the fix, that legacy block should be retired in favor
-    of the per-project section — keeping both would leave a stale entry."""
+    of the per-project section when it points at the same project."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text(
+        '[mcp_servers.context-engine]\n'
+        'command = "/old/cce"\n'
+        f'args = ["serve", "--project-dir", "{project_dir}"]\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+    content = user_config.read_text()
+    assert "[mcp_servers.context-engine]" not in content
+    assert f"[mcp_servers.cce-{_project_slug(project_dir)}]" in content
+
+
+def test_legacy_section_for_different_project_is_preserved(fake_home, project_dir):
+    """A user-managed legacy section for some other project should not be
+    removed just because this project is being configured."""
     (fake_home / ".codex").mkdir()
     user_config = fake_home / ".codex" / "config.toml"
     user_config.write_text(
@@ -262,7 +280,7 @@ def test_legacy_section_is_migrated_to_per_project(fake_home, project_dir):
     with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
         configure_mcp(project_dir, "codex")
     content = user_config.read_text()
-    assert "[mcp_servers.context-engine]" not in content
+    assert "[mcp_servers.context-engine]" in content
     assert f"[mcp_servers.cce-{_project_slug(project_dir)}]" in content
 
 
@@ -328,9 +346,28 @@ def test_remove_deletes_file_when_last_section_removed(fake_home, project_dir):
 
 def test_configure_does_not_crash_when_codex_path_is_a_file(fake_home, project_dir):
     """If ~/.codex exists as a regular file (antivirus quarantine, user
-    weirdness), configure_mcp must return False rather than blowing up
+    weirdness), configure_mcp must return None rather than blowing up
     the entire `cce init`."""
     (fake_home / ".codex").write_text("not a directory")
     with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
         result = configure_mcp(project_dir, "codex")
-    assert result is False
+    assert result is None
+
+
+def test_configure_returns_none_when_codex_config_cannot_be_written(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    with (
+        patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"),
+        patch("context_engine.editors.atomic_write_text", side_effect=OSError),
+    ):
+        result = configure_mcp(project_dir, "codex")
+    assert result is None
+
+
+def test_remove_returns_none_when_codex_config_cannot_be_read(fake_home, project_dir):
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text('[mcp_servers.linear]\ncommand = "x"\nargs = []\n')
+    with patch("pathlib.Path.read_text", side_effect=OSError):
+        result = remove_mcp(project_dir, "codex")
+    assert result is None

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -364,6 +364,71 @@ def test_configure_returns_none_when_codex_config_cannot_be_written(fake_home, p
     assert result is None
 
 
+def test_configure_preserves_user_header_comment(fake_home, project_dir):
+    """A user comment at the top of ~/.codex/config.toml must survive both
+    configure and uninstall — earlier code stripped the whole file after
+    removing a section, which silently deleted that header."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    user_config.write_text(
+        "# my hand-written codex config\n"
+        "# do not auto-edit — actually go ahead, just keep this comment\n"
+        "\n"
+        '[mcp_servers.linear]\n'
+        'command = "linear-mcp"\n'
+        'args = []\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        configure_mcp(project_dir, "codex")
+        remove_mcp(project_dir, "codex")
+    content = user_config.read_text()
+    assert "# my hand-written codex config" in content
+    assert "actually go ahead, just keep this comment" in content
+    # Linear block is still parseable too.
+    parsed = tomllib.loads(content)
+    assert parsed["mcp_servers"]["linear"]["command"] == "linear-mcp"
+
+
+def test_configure_rewrites_section_when_command_drifts(fake_home, project_dir):
+    """A previous install wrote a section pointing at an old `cce` binary.
+    On the next `cce init` (with the binary now at a new path) we must
+    rewrite the section, not silently report 'already configured' and leave
+    Codex pointed at a stale executable."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    slug = _project_slug(project_dir)
+    user_config.write_text(
+        f"[mcp_servers.cce-{slug}]\n"
+        'command = "/old/path/to/cce"\n'
+        f'args = ["serve", "--project-dir", "{project_dir}"]\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/new/path/to/cce"):
+        changed = configure_mcp(project_dir, "codex")
+    assert changed is True
+    parsed = tomllib.loads(user_config.read_text())
+    entry = parsed["mcp_servers"][f"cce-{slug}"]
+    assert entry["command"] == "/new/path/to/cce"
+
+
+def test_configure_rewrites_section_when_args_drift(fake_home, project_dir):
+    """User (or older code) hand-edited args to something stale. cce init
+    must restore the canonical args rather than reporting no-change."""
+    (fake_home / ".codex").mkdir()
+    user_config = fake_home / ".codex" / "config.toml"
+    slug = _project_slug(project_dir)
+    user_config.write_text(
+        f"[mcp_servers.cce-{slug}]\n"
+        'command = "/usr/bin/cce"\n'
+        'args = ["serve", "--project-dir", "/some/other/path"]\n'
+    )
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        changed = configure_mcp(project_dir, "codex")
+    assert changed is True
+    parsed = tomllib.loads(user_config.read_text())
+    entry = parsed["mcp_servers"][f"cce-{slug}"]
+    assert entry["args"] == ["serve", "--project-dir", str(project_dir)]
+
+
 def test_remove_returns_none_when_codex_config_cannot_be_read(fake_home, project_dir):
     (fake_home / ".codex").mkdir()
     user_config = fake_home / ".codex" / "config.toml"


### PR DESCRIPTION
## Summary

`cce init` now detects Codex via `~/.codex/` (where it actually lives) and writes per-project sections to `~/.codex/config.toml` so multiple projects can coexist. Closes #24.

## Why this was broken

Codex CLI reads MCP servers from `~/.codex/config.toml` only — it has no per-project config. The previous code looked for `<project>/.codex/` and wrote to `<project>/.codex/config.toml`. A user with a normal Codex install (issue #24 reporter's setup: `~/.codex` exists, no project-local `.codex/`) saw `cce init` silently skip Codex.

## What changed

1. **EDITORS gains `scope: "user"`.** A new optional field on each editor definition. `"project"` is the default and matches today's behavior. `"user"` resolves `config_path` and `detect` markers under `Path.home()` instead of under `project_dir`. Single conceptual flag, branched in three places via a `_scope_root()` helper.

2. **Per-project section names for Codex.** Section template is `mcp_servers.cce-{slug}` where `slug = <sanitised-basename>-<6-hex of sha256(absolute path)>`. Two projects sharing a basename ("api", "web") get distinct sections. Symlinks are resolved before slug computation so re-running `cce init` via different paths to the same directory is idempotent.

3. **Symmetric uninstall.** `cce uninstall` in project X removes only its `[mcp_servers.cce-X-...]` section. Other projects' Codex registrations and unrelated user `[mcp_servers.*]` sections stay intact.

## Bonus fixes folded in

- **Windows TOML escaping.** `_codex_toml_block` now escapes backslashes and quotes — the bug Copilot flagged on PR #20. Without it, `C:\Users\foo` interpolated into a double-quoted TOML string produces invalid TOML (`\U` is a Unicode escape). Test asserts the block round-trips through `tomllib.loads`.
- **Legacy section migration.** Anyone who hit the previous broken code path got `[mcp_servers.context-engine]` written into their (wrong) project-local TOML. If we encounter that legacy section on first run, it's replaced by the new per-project section in place.
- **Atomic writes.** `_configure_toml` switched from raw `write_text` to `atomic_write_text` (matches the JSON editors) so a crash mid-write can't corrupt the user's `~/.codex/config.toml`.
- **Defensive parent-mkdir.** Wrapped in `except OSError` so exotic states (`~/.codex` exists as a regular file, read-only home) treat the editor as not configurable rather than crashing all of `cce init`.
- **CLI message.** User-scoped editors print the resolved path + section name so the user can see exactly what landed where:
  ```
  ✓ MCP server registered for OpenAI Codex
      ~/.codex/config.toml  →  [mcp_servers.cce-myapp-3644da]
  ```

## Test plan

- [x] 23 new tests in `tests/test_editors_codex.py` pin: detection, slug behavior (determinism, collisions, symlinks, sanitization, empty-basename fallback), TOML escaping (unit + Windows round-trip via `tomllib`), configure (user-global write target, idempotency, multi-project coexistence, preserving unrelated user sections), legacy migration, removal (scoped to this project), and defensive filesystem handling.
- [x] All 820 existing + new tests pass (was 797 on main).
- [x] End-to-end smoke test confirms `detect_editors` finds Codex via `~/.codex/`, `configure_mcp` writes a valid TOML block to `~/.codex/config.toml` with the right section, and the project-local `<project>/.codex/config.toml` is no longer touched.
- [ ] Manual: install on a real machine with `~/.codex` and `~/.claude.json`, run `cce init`, confirm both Claude and Codex are configured and Codex actually picks up the new MCP server on next launch.

## Migration note for existing users

Anyone with a stale `<project>/.codex/config.toml` from the previous broken code path can safely delete it — Codex never read that file. The legacy `[mcp_servers.context-engine]` block (if it exists in `~/.codex/config.toml`) is auto-migrated on next `cce init`.