### PR TITLE
fix(windows): resolve Unicode crash and cce.exe binary lookup

### DIFF
--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -12,9 +12,11 @@ import click
 # and symbol characters used in CCE's output. Reconfigure to UTF-8 early so
 # output doesn't crash on first run. errors='replace' is a safety net in case
 # the terminal still can't render a character.
-if sys.platform.startswith("win") and hasattr(sys.stdout, "reconfigure"):
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+if sys.platform.startswith("win"):
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 from context_engine.config import load_config, resolve_ollama_url, PROJECT_CONFIG_NAME
 

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -8,6 +8,14 @@ from pathlib import Path
 
 import click
 
+# Windows consoles default to cp1252 which can't encode the Unicode box-drawing
+# and symbol characters used in CCE's output. Reconfigure to UTF-8 early so
+# output doesn't crash on first run. errors='replace' is a safety net in case
+# the terminal still can't render a character.
+if sys.platform.startswith("win") and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 from context_engine.config import load_config, resolve_ollama_url, PROJECT_CONFIG_NAME
 
 

--- a/src/context_engine/indexer/git_hooks.py
+++ b/src/context_engine/indexer/git_hooks.py
@@ -15,10 +15,15 @@ def _resolve_cce_binary() -> str:
     runs `git commit` from a shell that doesn't pick up the same PATH as the one
     used to install the engine (e.g. different login shell, GUI git client).
     """
-    candidate = Path(sys.executable).parent / "cce"
+    # On Windows the launcher is cce.exe; on POSIX it has no extension.
+    exe_suffix = ".exe" if sys.platform.startswith("win") else ""
+    candidate = Path(sys.executable).parent / f"cce{exe_suffix}"
     if candidate.exists():
         return str(candidate)
-    which = shutil.which("cce") or shutil.which("code-context-engine")
+    which = (
+        shutil.which("cce") or shutil.which("code-context-engine")
+        or shutil.which("cce.exe")  # Windows fallback
+    )
     if which:
         return which
     # Last-resort: rely on PATH at hook-run time.

--- a/src/context_engine/utils.py
+++ b/src/context_engine/utils.py
@@ -50,16 +50,26 @@ def atomic_write_text(path: Path, data: str) -> None:
 def resolve_cce_binary() -> str:
     """Find the globally installed cce binary path.
 
-    Checks user-local then system install paths across both Linux and macOS
-    (Homebrew on Apple Silicon installs to /opt/homebrew/bin), then PATH,
-    then sys.argv[0] if it looks like cce, then a bare "cce" fallback.
+    Checks user-local then system install paths across Linux, macOS, and
+    Windows, then PATH, then sys.argv[0] if it looks like cce, then a bare
+    "cce" fallback.
     """
-    candidates = [
-        Path.home() / ".local" / "bin" / "cce",   # pipx / uv tool default (Linux + macOS)
-        Path("/opt/homebrew/bin/cce"),            # macOS Homebrew on Apple Silicon
-        Path("/usr/local/bin/cce"),               # macOS Homebrew on Intel + Linux /usr/local
-        Path("/opt/local/bin/cce"),               # MacPorts
-    ]
+    if sys.platform.startswith("win"):
+        local_data = Path(os.environ.get("LOCALAPPDATA", ""))
+        app_data = Path(os.environ.get("APPDATA", ""))
+        candidates = [
+            Path.home() / ".local" / "bin" / "cce.exe",          # uv tool (Windows)
+            app_data / "uv" / "tools" / "code-context-engine" / "Scripts" / "cce.exe",
+            local_data / "uv" / "tools" / "code-context-engine" / "Scripts" / "cce.exe",
+            app_data / "Python" / "Scripts" / "cce.exe",          # pipx (Windows)
+        ]
+    else:
+        candidates = [
+            Path.home() / ".local" / "bin" / "cce",   # pipx / uv tool default (Linux + macOS)
+            Path("/opt/homebrew/bin/cce"),            # macOS Homebrew on Apple Silicon
+            Path("/usr/local/bin/cce"),               # macOS Homebrew on Intel + Linux /usr/local
+            Path("/opt/local/bin/cce"),               # MacPorts
+        ]
     for candidate in candidates:
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)
@@ -67,6 +77,6 @@ def resolve_cce_binary() -> str:
     if found:
         return found
     arg0 = Path(sys.argv[0]).resolve()
-    if arg0.name in ("cce", "code-context-engine"):
+    if arg0.name in ("cce", "cce.exe", "code-context-engine", "code-context-engine.exe"):
         return str(arg0)
     return "cce"


### PR DESCRIPTION
## Summary

Three bugs hit on a fresh Windows 11 install (`uv tool install code-context-engine`, Python 3.12):

- **Unicode crash on every `cce` command** — Windows consoles default to cp1252 which cannot encode the box-drawing and symbol characters (─, ✓, →, ●) used throughout CCE's output. Every command crashed immediately with `UnicodeEncodeError: 'charmap' codec can't encode character`. Fixed by reconfiguring stdout/stderr to UTF-8 at `cli.py` module load.

- **`resolve_cce_binary()` had no Windows paths** — `utils.py` only checked POSIX/Homebrew locations. On Windows, `uv tool install` places `cce.exe` in `%APPDATA%\uv\tools\code-context-engine\Scripts\` and `~\.local\bin\`. Without a match, the function fell through to a bare `"cce"` string — breaking `.mcp.json` when the tools directory isn't on PATH yet.

- **`git_hooks._resolve_cce_binary()` missed `.exe`** — looked for `cce` (no extension) next to `sys.executable`; on Windows the launcher is `cce.exe`. Git hooks installed with the wrong path silently did nothing on commit.

## Files changed

| File | Fix |
|------|-----|
| `src/context_engine/cli.py` | `sys.stdout/stderr.reconfigure(encoding="utf-8")` on Windows at module load |
| `src/context_engine/utils.py` | Windows candidate paths for `cce.exe` (uv + pipx); `.exe` in argv0 check |
| `src/context_engine/indexer/git_hooks.py` | `.exe` suffix on Windows; `shutil.which("cce.exe")` fallback |

## Test environment

Windows 11 Home (10.0.26200), Python 3.12.6, uv 0.9.30, `uv tool install code-context-engine`.

Verified `cce init`, `cce search`, `cce serve`, and `cce dashboard` all run cleanly after these fixes. The `.mcp.json` written by `cce init` correctly resolves to the absolute `cce.exe` path.

Closes #30