### PR TITLE
fix: complete uninstall cleanup (settings.json + gitignore)

### DIFF
--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1926,13 +1926,14 @@ def uninstall(yes: bool) -> None:
     gitignore = project_dir / ".gitignore"
     if gitignore.exists():
         content = gitignore.read_text()
-        if ".cce" in content or "context-engine" in content.lower() or "cce" in content.lower():
+        if ".cce" in content or "context-engine" in content.lower() or "cce" in content.lower() or ".claude/settings.local.json" in content:
+            # These are the exact entries CCE adds (see project_commands._GITIGNORE_ENTRIES)
+            cce_lines = {".cce/", ".claude/settings.local.json"}
             new_lines = [
                 line for line in content.splitlines()
-                if ".cce" not in line
+                if line.strip() not in cce_lines
                 and "context-engine" not in line.lower()
-                and not (line.startswith("#") and "cce" in line.lower())
-                and "claude code local settings" not in line.lower()
+                and not (line.startswith("#") and ("cce" in line.lower() or "claude code local settings" in line.lower()))
             ]
             new_content = "\n".join(new_lines).strip()
             if new_content:


### PR DESCRIPTION
## Summary

- Uninstall now removes CCE hooks from both `settings.json` AND `settings.local.json`
- Uninstall removes `.claude/settings.local.json` entry from `.gitignore`
- Empty `.claude/` directory is removed after cleaning hooks
- Previously, uninstall left behind `.claude/settings.json` (with 5 hooks) and a stale `.gitignore`

Fixes the issue where `cce uninstall` left artifacts behind.