### PR TITLE
chore: add issue templates for bug reports and feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Fill in what you can — the more detail, the faster we can fix it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "e.g. Running `cce index` hangs indefinitely on my monorepo."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      placeholder: "e.g. Indexing should complete and print a summary."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `cce init` in a repo with >10k files
+        2. Run `cce index`
+        3. Wait — it never finishes
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any terminal output or stack traces here.
+      render: shell
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.11.4"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "e.g. macOS 14.4, Ubuntu 22.04, Windows 11"
+    validations:
+      required: true
+
+  - type: input
+    id: cce-version
+    attributes:
+      label: CCE version
+      description: Run `cce --version` to get this.
+      placeholder: "e.g. 0.3.1"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/elara-labs/code-context-engine/discussions
+    about: Not a bug and not feedback? Ask a question or start a discussion here.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,47 @@
+name: Feedback / First Experience
+description: Tried CCE? Tell us how it went — good or bad.
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You don't need a polished bug report to share feedback. If you tried CCE and formed an opinion, we want to hear it.
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Did it work for you?
+      options:
+        - "Yes — worked out of the box"
+        - "Mostly — with some friction"
+        - "No — couldn't get it running"
+        - "Haven't tried yet — sharing a thought"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: What were you trying to do?
+      placeholder: "e.g. Use CCE with Claude on a TypeScript monorepo to reduce token usage."
+    validations:
+      required: true
+
+  - type: textarea
+    id: friction
+    attributes:
+      label: What was confusing or painful?
+      description: Setup, docs, config, output quality — anything. Honest feedback is more useful than polite feedback.
+      placeholder: "e.g. Took me 20 mins to figure out the MCP config format. The error message wasn't helpful."
+
+  - type: textarea
+    id: liked
+    attributes:
+      label: What worked well?
+      placeholder: "e.g. Token savings were immediately obvious. The hybrid search quality was better than I expected."
+
+  - type: input
+    id: stack
+    attributes:
+      label: Your stack (optional)
+      placeholder: "e.g. Python 3.12, VS Code, Claude Sonnet 4.5, macOS"


### PR DESCRIPTION
## Summary

- Adds `bug_report.yml` — structured fields for repro steps, logs, Python version, OS, and CCE version to reduce back-and-forth on bug reports
- Adds `feedback.yml` — lightweight first-experience form to capture signal from users who tried CCE but wouldn't open a formal bug report
- Adds `config.yml` — disables blank issues and routes general questions to Discussions once that tab is enabled

## Context

Investigation in #31 found that the repo has 14 forks with 0 commits ahead of main — people are interested but have no low-friction path to engage. The blank issue box is one of the most well-documented drop-off points in open source. These templates remove that barrier.

## Test plan

- [ ] Open a new issue on the repo and verify the template chooser appears
- [ ] Step through the bug report form — all required fields should block submission if empty
- [ ] Step through the feedback form — only `outcome` and `use-case` are required
- [ ] Verify blank issues are disabled and the Discussions link appears in the chooser