### PR TITLE
chore: release v0.4.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ cd /path/to/your/project
 cce init                              # index, install hooks, register MCP server
 ```
 
+**Embedding backends:** CCE auto-detects the best available backend. If you have Ollama running, it uses `nomic-embed-text` with zero extra dependencies. For offline/local embedding without Ollama, install the `[local]` extra:
+
+```bash
+uv tool install "code-context-engine[local]"   # includes fastembed + ONNX Runtime
+```
+
 Restart your editor. Done. Every question now hits the index instead of re-reading files.
 
 `cce init` auto-detects your editor and writes the right config:
@@ -375,11 +381,12 @@ Tell Claude: "switch to max compression" or "turn off compression". Code blocks 
 
 | Component | Size |
 |-----------|------|
-| Installed package | ~189 MB (ONNX Runtime is 66 MB of that) |
-| Embedding model (one-time download) | ~60 MB |
+| Core install (Ollama backend) | ~17 MB |
+| With `[local]` extra (fastembed + ONNX) | ~189 MB |
+| Embedding model (one-time download) | ~60 MB (fastembed) or managed by Ollama |
 | Index per project (small/medium/large) | 5-60 MB |
 
-No GPU required. Embedding model runs on CPU via ONNX Runtime.
+No GPU required. With Ollama, embeddings are handled by the Ollama server. With the `[local]` extra, the embedding model runs on CPU via ONNX Runtime.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
     "operatingSystem": "macOS, Linux, Windows",
     "license": "https://opensource.org/licenses/MIT",
     "downloadUrl": "https://pypi.org/project/code-context-engine/",
-    "softwareVersion": "0.4.18",
+    "softwareVersion": "0.4.20",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Organization", "name": "Elara Labs", "url": "https://github.com/elara-labs" }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "code-context-engine"
-version = "0.4.19"
+version = "0.4.20"
 description = "Save 94% on Claude Code tokens. Index your codebase locally, AI agents search instead of reading files. Reduce Claude API costs, save tokens on Cursor, VS Code, Gemini CLI. Free, open source MCP server."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/elara-labs/code-context-engine",
     "source": "github"
   },
-  "version": "0.4.19",
+  "version": "0.4.20",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "code-context-engine",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.20 (pyproject.toml, server.json, docs/index.html)
- Update README: document pluggable embedding backends (Ollama vs fastembed [local] extra), updated disk footprint table
- Update landing page softwareVersion schema

Includes since v0.4.19:
- Pluggable embedding backends, fastembed now optional (#62)
- Forkserver worker memory leak fix (#66)
- Setup/first-run pain points fix (#67)
- .mcp.json gitignored by default (#73)