### PR TITLE
feat: add `cce init --agent` flag for explicit agent targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@
 ```bash
 uv tool install code-context-engine
 cd /path/to/your/project
-cce init
+cce init                              # or: cce init --agent all
 ```
 
-That's it. Claude now searches your index instead of reading entire files. No config needed.
+That's it. Your AI coding agent now searches your index instead of reading entire files. No config needed.
 
 ---
 
@@ -106,21 +106,26 @@ uv tool install "code-context-engine[local]"   # includes fastembed + ONNX Runti
 
 Restart your editor. Done. Every question now hits the index instead of re-reading files.
 
-`cce init` auto-detects your editor and writes the right config:
+`cce init` auto-detects your editor and writes the right config. To target a
+specific agent, use `--agent claude`, `--agent codex`, `--agent copilot`, or
+`--agent all`.
 
 | Editor | Config written | Instructions |
 |--------|---------------|--------------|
 | Claude Code | `.mcp.json` | `CLAUDE.md` |
-| VS Code / Copilot | `.vscode/mcp.json` | |
+| VS Code / Copilot | `.vscode/mcp.json` | `.github/copilot-instructions.md` |
 | Cursor | `.cursor/mcp.json` | `.cursorrules` |
 | Gemini CLI | `.gemini/settings.json` | `GEMINI.md` |
-| OpenAI Codex | `~/.codex/config.toml` (user-global, per-project section) | |
+| OpenAI Codex | `~/.codex/config.toml` (user-global, per-project section) | `AGENTS.md` |
 | OpenCode | `opencode.json` | |
 | Tabnine | `.tabnine/agent/settings.json` | `TABNINE.md` |
 
 Multiple editors in the same project? All get configured in one command.
 
-**Codex note:** Codex CLI reads MCP servers from `~/.codex/config.toml` only — it has no per-project config. `cce init` adds one `[mcp_servers.cce-<project>-<hash>]` section per project so multiple projects coexist; `cce uninstall` removes only the section for the current project.
+**Codex note:** Codex CLI reads MCP servers from `~/.codex/config.toml` only —
+it has no per-project config. `cce init` adds one `[mcp_servers.cce-<project>-<hash>]`
+section per project so multiple projects coexist; `cce uninstall` removes only
+the section for the current project.
 
 ```
   my-project · 38 queries

--- a/docs/wiki/CLI-Reference.md
+++ b/docs/wiki/CLI-Reference.md
@@ -46,7 +46,7 @@ Shows every available command grouped by category:
 
 ```
   ── Setup ─────────────────────────────────────────
-    cce init                            Index project, install git hooks, write .mcp.json
+    cce init [--agent auto|all|...]     Index project and register MCP config
     cce index                           Re-index changed files
     cce index --full                    Force full re-index of every file
     cce index --path <file>             Index one file or directory
@@ -113,12 +113,15 @@ Shows every available command grouped by category:
 
 ## cce init
 
-One-time setup for a project. Checks dependencies, indexes all code, installs git hooks, and connects Claude Code via MCP.
+One-time setup for a project. Checks dependencies, indexes all code, installs git hooks, and connects AI coding agents via MCP.
 
 ```bash
 cd /path/to/your/project
 cce init
 ```
+
+Use `--agent claude`, `--agent codex`, `--agent copilot`, or `--agent all` to
+target a specific integration instead of auto-detection.
 
 **Expected output:**
 
@@ -140,7 +143,7 @@ cce init
 
   ✓ Indexed 1,247 chunks from 89 files
 
-  Done!  Restart Claude Code to activate CCE.
+  Done!  Restart your AI coding agent to activate CCE.
 ```
 
 **With Ollama running:**
@@ -162,8 +165,8 @@ cce init
 - Checks Ollama status and reports compression mode
 - Builds vector, FTS, and graph indexes
 - Installs `post-commit` and `pre-push` git hooks
-- Writes `.mcp.json` pointing Claude Code at the MCP server
-- Creates or updates `CLAUDE.md` with CCE instructions
+- Writes MCP config for selected agents (`.mcp.json`, `.vscode/mcp.json`, or `~/.codex/config.toml`)
+- Creates or updates agent instruction files (`CLAUDE.md`, `AGENTS.md`, or `.github/copilot-instructions.md`)
 - Adds per-machine files to `.gitignore`
 
 ---

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -681,10 +681,62 @@ def main(ctx: click.Context, verbose: bool) -> None:
         _show_welcome_banner(ctx.obj["config"])
 
 
+_INIT_AGENT_CHOICES = ("auto", "claude", "codex", "copilot", "all")
+_INIT_AGENT_TO_EDITORS = {
+    "claude": {"claude"},
+    "codex": {"codex"},
+    "copilot": {"vscode"},
+}
+# Editor key → instruction-file key. `claude` is omitted because CLAUDE.md is
+# written by `_ensure_claude_md`, not via the generic instruction-file path.
+# `opencode` has no instruction file.
+_INIT_EDITOR_TO_INSTRUCTIONS = {
+    "codex": "agents",
+    "vscode": "copilot",
+    "cursor": "cursorrules",
+    "gemini": "gemini",
+    "tabnine": "tabnine",
+}
+
+
+def _init_editor_targets(project_dir: Path, agent: str) -> set[str]:
+    """Return editor keys to configure for `cce init --agent`.
+
+    - `all`: every editor in EDITORS (computed at call time so the set never
+      drifts when new editors are added).
+    - `auto`: Claude plus any editor whose project/home markers exist.
+    - explicit (`claude`/`codex`/`copilot`): exactly the editors that flag
+      maps to.
+    """
+    from context_engine.editors import EDITORS, detect_editors
+
+    if agent == "all":
+        return set(EDITORS.keys())
+    if agent != "auto":
+        return set(_INIT_AGENT_TO_EDITORS[agent])
+    return {"claude", *detect_editors(project_dir)}
+
+
+def _init_instruction_targets(editor_targets: set[str]) -> set[str]:
+    """Instruction-file keys derived from the selected editors."""
+    return {
+        file_key
+        for editor_key, file_key in _INIT_EDITOR_TO_INSTRUCTIONS.items()
+        if editor_key in editor_targets
+    }
+
+
 @main.command()
+@click.option(
+    "--agent",
+    type=click.Choice(_INIT_AGENT_CHOICES),
+    default="auto",
+    show_default=True,
+    help="Agent/editor target: auto, claude, codex, copilot, or all.",
+)
 @click.pass_context
-def init(ctx: click.Context) -> None:
-    """Initialize context engine and connect it to Claude Code."""
+def init(ctx: click.Context, agent: str) -> None:
+    """Initialize context engine and connect it to AI coding agents."""
     from context_engine.indexer.git_hooks import install_hooks
     from context_engine.project_commands import ensure_gitignore
     config = ctx.obj["config"]
@@ -719,23 +771,24 @@ def init(ctx: click.Context) -> None:
         _warn("Not a git repository — git hook skipped")
         click.echo(_dim("    Run `cce index` manually after making changes."))
 
-    # 4. MCP config — Claude Code + any detected editors
+    # 4. MCP config — selected agents/editors
     from context_engine.editors import (
         EDITORS, INSTRUCTION_FILES,
-        detect_editors, configure_mcp, write_instruction_file,
+        configure_mcp, write_instruction_file,
     )
-    configured = _configure_mcp(project_dir)
-    if configured:
-        _ok("MCP server registered in " + click.style(".mcp.json", fg="cyan"))
-    else:
-        _ok("MCP server already configured in " + click.style(".mcp.json", fg="cyan"))
-
-    # Configure MCP for other detected editors (Cursor, VS Code, Gemini, Codex, Tabnine)
     from context_engine.editors import _editor_section  # noqa: SLF001
-    detected = detect_editors(project_dir)
-    for editor_key in detected:
+
+    editor_targets = _init_editor_targets(project_dir, agent)
+    if "claude" in editor_targets:
+        configured = _configure_mcp(project_dir)
+        if configured:
+            _ok("MCP server registered in " + click.style(".mcp.json", fg="cyan"))
+        else:
+            _ok("MCP server already configured in " + click.style(".mcp.json", fg="cyan"))
+
+    for editor_key in sorted(editor_targets):
         if editor_key == "claude":
-            continue  # already handled above
+            continue
         editor = EDITORS[editor_key]
         changed = configure_mcp(project_dir, editor_key)
         if changed is None:
@@ -751,19 +804,26 @@ def init(ctx: click.Context) -> None:
             section = _editor_section(editor, project_dir)
             click.echo(_dim(f"    ~/{editor['config_path']}  →  [{section}]"))
 
-    # Write instruction files for detected editors
-    for file_key, info in INSTRUCTION_FILES.items():
-        for marker in info["detect"]:
-            if (project_dir / marker).exists():
-                if write_instruction_file(project_dir, file_key):
-                    _ok(f"CCE instructions added to {info['name']}")
-                break
+    # Write instruction files for the selected editors. In `auto` mode, also
+    # pick up instruction files whose marker exists even if the editor itself
+    # wasn't detected (e.g. an `AGENTS.md` checked in without a `~/.codex/`).
+    # Explicit `--agent X` writes only what X covers — no surprise edits.
+    instruction_targets = _init_instruction_targets(editor_targets)
+    if agent == "auto":
+        for file_key, info in INSTRUCTION_FILES.items():
+            if any((project_dir / marker).exists() for marker in info["detect"]):
+                instruction_targets.add(file_key)
+    for file_key in sorted(instruction_targets):
+        info = INSTRUCTION_FILES[file_key]
+        if write_instruction_file(project_dir, file_key):
+            _ok(f"CCE instructions added to {info['name']}")
 
     # 5. CLAUDE.md + session hook + memory lifecycle hooks
-    _ensure_claude_md(project_dir)
-    _ensure_session_hook(project_dir)
-    _install_memory_hooks(project_dir)
-    _check_memory_capture_reachable(config, project_dir)
+    if "claude" in editor_targets:
+        _ensure_claude_md(project_dir)
+        _ensure_session_hook(project_dir)
+        _install_memory_hooks(project_dir)
+        _check_memory_capture_reachable(config, project_dir)
 
     # 6. .gitignore — add CCE per-machine entries
     ensure_gitignore(str(project_dir))
@@ -777,7 +837,7 @@ def init(ctx: click.Context) -> None:
     click.echo("")
     click.echo(
         click.style("  Done!", fg="green", bold=True) +
-        click.style("  Restart Claude Code to activate CCE.", fg="white")
+        click.style("  Restart your AI coding agent to activate CCE.", fg="white")
     )
     click.echo("")
 
@@ -962,7 +1022,7 @@ def list_commands() -> None:
 
     groups = [
         ("Setup", [
-            ("cce init", "Index project, install git hooks, write .mcp.json"),
+            ("cce init [--agent auto|all|...]", "Index project and register MCP config"),
             ("cce index", "Re-index changed files"),
             ("cce index --full", "Force full re-index of every file"),
             ("cce index --path <file>", "Index one file or directory"),
@@ -2197,7 +2257,7 @@ def upgrade(ctx: click.Context, check: bool) -> None:
     click.echo("")
     click.echo(
         click.style("  Done!", fg="green", bold=True) +
-        click.style("  Restart Claude Code to pick up changes.", fg="white")
+        click.style("  Restart your AI coding agent to pick up changes.", fg="white")
     )
     click.echo("")
 

--- a/src/context_engine/editors.py
+++ b/src/context_engine/editors.py
@@ -123,6 +123,16 @@ Call `record_code_area(file_path="...", description="...")` after meaningful wor
 """
 
 INSTRUCTION_FILES: dict[str, dict] = {
+    "agents": {
+        "name": "AGENTS.md",
+        "path": "AGENTS.md",
+        "detect": ["AGENTS.md"],
+    },
+    "copilot": {
+        "name": ".github/copilot-instructions.md",
+        "path": ".github/copilot-instructions.md",
+        "detect": [".github/copilot-instructions.md"],
+    },
     "cursorrules": {
         "name": ".cursorrules",
         "path": ".cursorrules",
@@ -563,6 +573,7 @@ def write_instruction_file(project_dir: Path, file_key: str) -> bool:
     info = INSTRUCTION_FILES[file_key]
     path = project_dir / info["path"]
     marker = "## Context Engine (CCE)"
+    path.parent.mkdir(parents=True, exist_ok=True)
 
     if path.exists():
         content = path.read_text()

--- a/tests/test_cli_init_agents.py
+++ b/tests/test_cli_init_agents.py
@@ -1,0 +1,155 @@
+"""Tests for `cce init --agent` target selection and generated files."""
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from context_engine.cli import _init_editor_targets, main
+from context_engine.editors import _project_slug
+
+
+async def _noop_index(*args, **kwargs):
+    return None
+
+
+def test_init_all_targets_every_known_editor():
+    from context_engine.editors import EDITORS
+    assert _init_editor_targets(Path("/tmp/anywhere"), "all") == set(EDITORS.keys())
+
+
+def test_init_codex_writes_codex_config_and_agents_md(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr("context_engine.cli._preflight_check", lambda config: None)
+    monkeypatch.setattr("context_engine.cli._run_index", _noop_index)
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        result = runner.invoke(main, ["init", "--agent", "codex"], catch_exceptions=False, obj={})
+
+    assert result.exit_code == 0
+    assert (project / "AGENTS.md").exists()
+    assert not (project / "CLAUDE.md").exists()
+    assert not (project / ".mcp.json").exists()
+
+    codex_config = fake_home / ".codex" / "config.toml"
+    parsed = tomllib.loads(codex_config.read_text())
+    entry = parsed["mcp_servers"][f"cce-{_project_slug(project)}"]
+    assert entry["command"] == "/usr/bin/cce"
+    assert entry["args"] == ["serve", "--project-dir", str(project)]
+
+
+def test_init_claude_does_not_write_other_instruction_files(tmp_path, monkeypatch):
+    """`--agent claude` must not append CCE block to pre-existing AGENTS.md or
+    copilot-instructions.md just because their files happen to exist."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "AGENTS.md").write_text("# Existing agents\n")
+    (project / ".github").mkdir()
+    (project / ".github" / "copilot-instructions.md").write_text("# Existing copilot\n")
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr("context_engine.cli._preflight_check", lambda config: None)
+    monkeypatch.setattr("context_engine.cli._run_index", _noop_index)
+    monkeypatch.setattr("context_engine.cli._check_memory_capture_reachable", lambda config, project: None)
+    monkeypatch.setattr("context_engine.cli._ensure_session_hook", lambda project: None)
+    monkeypatch.setattr("context_engine.cli._install_memory_hooks", lambda project: None)
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"), patch(
+        "context_engine.utils.resolve_cce_binary", return_value="/usr/bin/cce"
+    ):
+        result = runner.invoke(main, ["init", "--agent", "claude"], catch_exceptions=False, obj={})
+
+    assert result.exit_code == 0
+    assert (project / "AGENTS.md").read_text() == "# Existing agents\n"
+    assert (project / ".github" / "copilot-instructions.md").read_text() == "# Existing copilot\n"
+    assert (project / "CLAUDE.md").exists()
+    assert (project / ".mcp.json").exists()
+
+
+def test_init_copilot_writes_vscode_config_and_copilot_instructions(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr("context_engine.cli._preflight_check", lambda config: None)
+    monkeypatch.setattr("context_engine.cli._run_index", _noop_index)
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
+        result = runner.invoke(main, ["init", "--agent", "copilot"], catch_exceptions=False, obj={})
+
+    assert result.exit_code == 0
+    assert (project / ".github" / "copilot-instructions.md").exists()
+    vscode_mcp = json.loads((project / ".vscode" / "mcp.json").read_text())
+    assert vscode_mcp["servers"]["context-engine"]["command"] == "/usr/bin/cce"
+    assert not (project / "CLAUDE.md").exists()
+    assert not (project / ".mcp.json").exists()
+    assert not (project / "AGENTS.md").exists()
+
+
+def test_init_all_writes_every_editor_config_and_instruction_file(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr("context_engine.cli._preflight_check", lambda config: None)
+    monkeypatch.setattr("context_engine.cli._run_index", _noop_index)
+    monkeypatch.setattr("context_engine.cli._check_memory_capture_reachable", lambda config, project: None)
+    monkeypatch.setattr("context_engine.cli._ensure_session_hook", lambda project: None)
+    monkeypatch.setattr("context_engine.cli._install_memory_hooks", lambda project: None)
+    monkeypatch.chdir(project)
+
+    runner = CliRunner()
+    with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"), patch(
+        "context_engine.utils.resolve_cce_binary", return_value="/usr/bin/cce"
+    ):
+        result = runner.invoke(main, ["init", "--agent", "all"], catch_exceptions=False, obj={})
+
+    assert result.exit_code == 0
+
+    # Instruction files for every editor that has one (Claude is via _ensure_claude_md;
+    # OpenCode has no instruction file).
+    assert (project / "CLAUDE.md").exists()
+    assert (project / "AGENTS.md").exists()
+    assert (project / ".github" / "copilot-instructions.md").exists()
+    assert (project / ".cursorrules").exists()
+    assert (project / "GEMINI.md").exists()
+    assert (project / "TABNINE.md").exists()
+
+    # MCP configs for every editor.
+    claude_mcp = json.loads((project / ".mcp.json").read_text())
+    assert claude_mcp["mcpServers"]["context-engine"]["command"] == "/usr/bin/cce"
+
+    vscode_mcp = json.loads((project / ".vscode" / "mcp.json").read_text())
+    assert vscode_mcp["servers"]["context-engine"]["command"] == "/usr/bin/cce"
+
+    cursor_mcp = json.loads((project / ".cursor" / "mcp.json").read_text())
+    assert cursor_mcp["mcpServers"]["context-engine"]["command"] == "/usr/bin/cce"
+
+    gemini_mcp = json.loads((project / ".gemini" / "settings.json").read_text())
+    assert gemini_mcp["mcpServers"]["context-engine"]["command"] == "/usr/bin/cce"
+
+    opencode_mcp = json.loads((project / "opencode.json").read_text())
+    assert opencode_mcp["mcp"]["context-engine"]["command"][0] == "/usr/bin/cce"
+
+    tabnine_mcp = json.loads((project / ".tabnine" / "agent" / "settings.json").read_text())
+    assert tabnine_mcp["mcpServers"]["context-engine"]["command"] == "/usr/bin/cce"
+
+    codex_config = tomllib.loads((fake_home / ".codex" / "config.toml").read_text())
+    assert f"cce-{_project_slug(project)}" in codex_config["mcp_servers"]


### PR DESCRIPTION
## Summary

Adds `--agent {auto,claude,codex,copilot,all}` to `cce init` so users can target a specific AI coding agent instead of the historical Claude-first behavior.

- **`auto`** (default): Claude plus any editor whose project/home markers exist — preserves prior behavior.
- **`all`**: every editor in `EDITORS` — Claude, Codex, VS Code/Copilot, Cursor, Gemini, OpenCode, Tabnine. Computed from `EDITORS.keys()` at call time so the set can never drift when new editors are added.
- **explicit** (`claude` / `codex` / `copilot`): only the editors that flag covers. The marker-based instruction-file fallback runs only under `auto`, so an explicit `--agent claude` no longer appends CCE blocks to a pre-existing `AGENTS.md` or `copilot-instructions.md`.

Also:
- New instruction-file targets: `AGENTS.md` (Codex) and `.github/copilot-instructions.md` (Copilot). Parent directories are created as needed.
- Claude-only setup (`CLAUDE.md`, session hook, memory hooks) is skipped when `claude` is not in the selected target set.

## Design notes

- `--agent all` is a literal "all" — matches the README table, removes a footgun where it previously meant only Claude+Codex+Copilot.
- The earlier runtime env-var detection (`CODEX_THREAD_ID`, `GITHUB_COPILOT_AGENT`, …) was dropped: the env vars couldn't be independently verified, and silently writing user-global config based on heuristics is the wrong default. Users in a Codex shell can run `cce init --agent codex` explicitly.
- Marker fallback restricted to `auto` so `--agent X` does exactly what the flag says — no surprise edits.

## Test plan

- [x] `tests/test_cli_init_agents.py` — 5 new tests covering `--agent all`, `--agent codex`, `--agent copilot`, `--agent claude` (no fallback edits), and `_init_editor_targets("all")` covers every key in `EDITORS`.
- [x] Full suite: `935 passed, 1 skipped` (was 933 + 1 pre-change).
- [ ] Manual: `cce init --agent codex` in a fresh project writes only `AGENTS.md` + `~/.codex/config.toml` section; no `.mcp.json` or `CLAUDE.md`.
- [ ] Manual: `cce init --agent claude` in a project with a checked-in `AGENTS.md` leaves it untouched.