### PR TITLE
Release v0.4.22

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
     "operatingSystem": "macOS, Linux, Windows",
     "license": "https://opensource.org/licenses/MIT",
     "downloadUrl": "https://pypi.org/project/code-context-engine/",
-    "softwareVersion": "0.4.21",
+    "softwareVersion": "0.4.22",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Organization", "name": "Elara Labs", "url": "https://github.com/elara-labs" }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "code-context-engine"
-version = "0.4.21"
+version = "0.4.22"
 description = "Save 94% on Claude Code tokens. Index your codebase locally, AI agents search instead of reading files. Reduce Claude API costs, save tokens on Cursor, VS Code, Gemini CLI. Free, open source MCP server."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/elara-labs/code-context-engine",
     "source": "github"
   },
-  "version": "0.4.21",
+  "version": "0.4.22",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "code-context-engine",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
Version bump to 0.4.22 for PyPI publish.

### What's new since 0.4.21
- Session-wide output compression via instruction files (CLAUDE.md, AGENTS.md, etc.)
- Abort `cce init` early when no embedding backend available (clean error instead of stack trace)
- Handle missing `sqlite3.enable_load_extension` on Python 3.14 (#85)
- Truncate oversized chunks before Ollama embedding (#86, #87)
- "Why CCE?" docs page with cost math and value proposition
- Default install command changed to `[local]` across all docs
- Updated demo GIF
- Starlight docs site with search at /guide/