### PR TITLE
docs: multi-agent SEO, docs link, fix JSON output corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://elara-labs.github.io/code-context-engine/">Website</a> · <a href="https://elara-labs.github.io/code-context-engine/blog/what-is-code-context-engine.html">Guide</a> · <a href="https://elara-labs.github.io/code-context-engine/blog/benchmark-fastapi.html">Benchmark</a> · <a href="https://github.com/elara-labs/code-context-engine">GitHub</a>
+  <a href="https://elara-labs.github.io/code-context-engine/">Website</a> · <a href="https://elara-labs.github.io/code-context-engine/guide/">Docs</a> · <a href="https://elara-labs.github.io/code-context-engine/guide/why-cce/">Why CCE?</a> · <a href="https://elara-labs.github.io/code-context-engine/blog/benchmark-fastapi.html">Benchmark</a> · <a href="https://github.com/elara-labs/code-context-engine">GitHub</a>
 </p>
 
 <br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Code Context Engine — Save 94% on Claude Code Tokens</title>
-  <meta name="description" content="Save 94% on Claude Code tokens. Code Context Engine indexes your codebase locally so AI agents search instead of reading entire files. Reduce Claude API costs, save tokens on Cursor, VS Code, Gemini CLI. Free, open source, benchmarked.">
-  <meta property="og:title" content="Code Context Engine — Save 94% on Claude Code Tokens">
-  <meta property="og:description" content="Stop paying to re-read code. Index your codebase, save 94% on input tokens. Local, free, open source.">
+  <title>Code Context Engine — Save 94% on AI Coding Tokens | Claude, Cursor, Codex, Copilot, Gemini</title>
+  <meta name="description" content="Save 94% on AI coding tokens. Local MCP server that indexes your codebase so Claude Code, Cursor, Codex, Copilot, and Gemini CLI search instead of reading entire files. Free, open source, benchmarked.">
+  <meta property="og:title" content="Code Context Engine — Save 94% on AI Coding Tokens">
+  <meta property="og:description" content="Stop paying to re-read code. Works with Claude Code, Cursor, Codex, Copilot, Gemini CLI. Index once, save 94%. Local, free, open source.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://elara-labs.github.io/code-context-engine/">
-  <meta name="keywords" content="save Claude Code tokens, reduce Claude API costs, Claude token savings, save AI coding tokens, MCP server for coding, Code Context Engine, reduce Cursor costs, AI coding agent tokens, save tokens Claude, save tokens Cursor, code indexing MCP">
+  <meta name="keywords" content="save AI coding tokens, reduce Claude Code costs, save Cursor tokens, Codex MCP server, Copilot token savings, Gemini CLI tokens, Code Context Engine, MCP server for coding, reduce AI coding costs, code indexing MCP, save Claude tokens, save Codex tokens, reduce Copilot costs, AI coding agent tokens, local code indexing">
   <link rel="canonical" href="https://elara-labs.github.io/code-context-engine/">
   <link rel="icon" type="image/svg+xml" href="logo.svg">
   <script type="application/ld+json">
@@ -18,7 +18,7 @@
     "@type": "SoftwareApplication",
     "name": "Code Context Engine",
     "alternateName": "CCE",
-    "description": "Save 94% on Claude Code tokens. Index your codebase locally, AI agents search instead of reading entire files.",
+    "description": "Save 94% on AI coding tokens. Index your codebase locally so Claude Code, Cursor, Codex, Copilot, and Gemini CLI search instead of reading entire files.",
     "url": "https://elara-labs.github.io/code-context-engine/",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "code-context-engine"
 version = "0.4.22"
-description = "Save 94% on Claude Code tokens. Index your codebase locally, AI agents search instead of reading files. Reduce Claude API costs, save tokens on Cursor, VS Code, Gemini CLI. Free, open source MCP server."
+description = "Save 94% on AI coding tokens. Index your codebase, agents search instead of reading files. Works with Claude Code, Cursor, Codex, Copilot, Gemini CLI. Local MCP server, free, open source."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"
 authors = [
     {name = "Fazle Elahee", email = "felahee@gmail.com"},
     {name = "Raj", email = "rajkumar.sakti@gmail.com"},
 ]
-keywords = ["claude-code", "save-tokens", "token-savings", "mcp-server", "claude", "cursor", "code-indexing", "reduce-ai-costs", "llm", "vector-search", "ai-coding"]
+keywords = ["claude-code", "codex", "copilot", "cursor", "gemini-cli", "save-tokens", "token-savings", "mcp-server", "code-indexing", "reduce-ai-costs", "ai-coding", "vector-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -790,8 +790,11 @@ def main(ctx: click.Context, verbose: bool) -> None:
 @click.pass_context
 def _after_command(ctx: click.Context, *_args, **_kwargs) -> None:
     """Run after every command. Shows update notice if available."""
-    # Skip for serve (long-running MCP server) and upgrade (already handles it)
+    # Skip for serve (long-running), upgrade (already handles it),
+    # and any --json output (would corrupt parseable output).
     if ctx.invoked_subcommand in ("serve", "upgrade"):
+        return
+    if "--json" in sys.argv:
         return
     _show_update_notice()
 


### PR DESCRIPTION
## Summary
- README header now links to `/guide/` docs site and "Why CCE?" page
- Landing page title, meta description, OG tags, structured data, and keywords updated to target all agents (Claude, Cursor, Codex, Copilot, Gemini) instead of Claude-only
- PyPI description and keywords updated for multi-agent
- Fix: update notification was appending to `--json` output, breaking JSON parsing