### PR TITLE
feat: README overhaul + savings badge CLI for growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,49 +66,38 @@
 
 ## Quick start
 
+Two commands. 30 seconds.
+
+```bash
+uvx --from "code-context-engine[local]" cce init    # install + index + configure, one shot
+```
+
+Or if you prefer a persistent install:
+
 ```bash
 uv tool install "code-context-engine[local]"    # or: pipx install "code-context-engine[local]"
 cd /path/to/your/project
-cce init                                        # or: cce init --agent all
-```
-
-That's it. Your AI coding agent now searches your index instead of reading entire files.
-
-> **Already have Ollama?** You can skip `[local]` and use `uv tool install code-context-engine` instead. CCE auto-detects Ollama at localhost:11434 and uses `nomic-embed-text`.
-
----
-
-## System requirements
-
-- Python 3.11+ (tested on 3.11, 3.12, 3.13)
-- A C compiler and `cmake` (needed to build tree-sitter grammars)
-
-| Platform | Setup |
-|----------|-------|
-| **macOS** | `xcode-select --install` (provides compiler and cmake) |
-| **Ubuntu/Debian** | `sudo apt install build-essential cmake` |
-| **Fedora/RHEL** | `sudo dnf install gcc gcc-c++ cmake` |
-| **Windows** | Install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (C++ workload) and [CMake](https://cmake.org/download/) |
-
-Tested on all three platforms in CI (macOS, Linux, Windows × Python 3.11/3.12/3.13).
-
-## Install and see savings in 60 seconds
-
-You need an embedding backend to index code. Pick one:
-
-| Option | Install command | Size | Requires |
-|--------|----------------|------|----------|
-| **Local (recommended)** | `uv tool install "code-context-engine[local]"` | +60 MB | Nothing else |
-| **Ollama** | `uv tool install code-context-engine` | Core only | Ollama running + `nomic-embed-text` pulled |
-
-Then:
-
-```bash
-cd /path/to/your/project
-cce init                              # index, install hooks, register MCP server
+cce init
 ```
 
 Restart your editor. Done. Every question now hits the index instead of re-reading files.
+
+> **Already have Ollama?** Skip `[local]` and use `uv tool install code-context-engine` instead. CCE auto-detects Ollama at localhost:11434 and uses `nomic-embed-text`.
+
+<details>
+<summary><strong>System requirements</strong></summary>
+
+Python 3.11+ and a C compiler (for tree-sitter grammars).
+
+| Platform | Setup |
+|----------|-------|
+| **macOS** | `xcode-select --install` |
+| **Ubuntu/Debian** | `sudo apt install build-essential cmake` |
+| **Fedora/RHEL** | `sudo dnf install gcc gcc-c++ cmake` |
+| **Windows** | [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (C++ workload) + [CMake](https://cmake.org/download/) |
+
+Tested on macOS, Linux, Windows with Python 3.11/3.12/3.13.
+</details>
 
 `cce init` auto-detects your editor and writes the right config. To target a
 specific agent, use `--agent claude`, `--agent codex`, `--agent copilot`, or
@@ -132,17 +121,24 @@ section per project so multiple projects coexist; `cce uninstall` removes only
 the section for the current project.
 
 ```
-  my-project · 38 queries
+  my-project · 38 queries · last query 5m ago
 
-  ⛁ ⛁ ⛁ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶  94% tokens saved
+  ⛁ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶  88% tokens saved
 
-  Without CCE   48.0k  tokens   $0.14
-  With CCE       3.4k  tokens   $0.01
+  Input savings   1.9M  tokens   $27.78
+  Output savings  4.8k  tokens   $0.36
   ──────────────────────────────────────────
-  Saved         44.6k  tokens   $0.13
+  Total saved   1.9M  tokens   $28.15
 
-  Cost estimate based on Sonnet input pricing ($3/1M tokens)
+  Breakdown:
+    retrieval              84%  ▰▰▰▰▰▰▰▰▰▰    1.8M   $26.76 · 12 calls
+    chunk compression       3%  ▰▱▱▱▱▱▱▱▱▱   68.5k    $1.03 · 12 calls
+    output compression*    <1%  ▰▱▱▱▱▱▱▱▱▱    4.8k    $0.36 · 12 calls
+
+  Cost estimate based on Opus pricing (input $15.0/1M, output $75.0/1M)
 ```
+
+Supports Anthropic, OpenAI, and Google model pricing. Configure via `pricing.model` in `~/.cce/config.yaml`.
 
 ---
 
@@ -236,7 +232,7 @@ cce dashboard
 
 ![CCE Dashboard](https://raw.githubusercontent.com/elara-labs/code-context-engine/main/docs/dashboard.png)
 
-**Dollar estimates** fetched from live Anthropic pricing:
+**Dollar estimates** with multi-provider pricing (Anthropic, OpenAI, Google):
 
 ```bash
 cce savings --all    # see savings across all projects
@@ -244,15 +240,7 @@ cce savings --all    # see savings across all projects
 
 ---
 
-## How is CCE different?
-
-CCE is editor-agnostic, local-first, and gives you measurable token savings. Your code never leaves your machine. Unlike built-in indexing (Cursor, Continue), CCE works across Claude Code, VS Code, Cursor, Gemini CLI, and Codex with a single index. Unlike cloud tools (Greptile), it's free and private.
-
-See the [full comparison with alternatives](docs/comparison.md) for an honest look at trade-offs.
-
----
-
-## How it works (the short version)
+## How it works
 
 1. **Index:** Tree-sitter parses your code into semantic chunks (functions, classes, modules). Stored as vector embeddings locally.
 2. **Search:** Claude calls `context_search`. Hybrid vector + BM25 retrieval finds the right chunks. Code graph adds related files automatically.
@@ -317,9 +305,9 @@ Memory entries compressed without LLM calls. Drops articles, fillers, pronouns. 
 </details>
 
 <details>
-<summary><strong>Dynamic Pricing</strong></summary>
+<summary><strong>Multi-Provider Pricing</strong></summary>
 
-Dollar estimates in `cce savings` come from live Anthropic pricing (HTML table parsed, cached 7 days, offline fallback). No manual updates when rates change.
+Dollar estimates in `cce savings` support 15+ models across Anthropic, OpenAI, and Google. Static pricing ships with CCE, live Anthropic pricing is fetched and cached 7 days. Configure `pricing.model` (e.g. `gpt-4o`, `gemini-2.5-pro`, `sonnet`) or override with `pricing.input` / `pricing.output` for custom rates.
 </details>
 
 <details>
@@ -364,7 +352,9 @@ retrieval:
   confidence_threshold: 0.5
 
 pricing:
-  model: sonnet            # sonnet | opus | haiku
+  model: opus              # opus | sonnet | haiku | gpt-4o | gemini-2.5-pro | ...
+  # input: 15.0            # override $/1M input tokens
+  # output: 75.0           # override $/1M output tokens
 ```
 
 **Remote Ollama:** If you run Ollama on another machine in your network, set `compression.ollama_url` (e.g. `http://nas.local:11434`) or export `CCE_OLLAMA_URL` — the env var wins. CCE probes the endpoint and falls back to truncation-only compression when it's unreachable, so a flaky link won't break indexing.
@@ -457,7 +447,7 @@ CCE replaces "dump the entire file" with "search for the relevant function." The
 
 CCE writes output compression rules directly into your agent's instruction files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, etc.) during `cce init`. These rules apply to the **entire session**, not just CCE tool responses, so every reply from the agent follows them.
 
-Set the level in `cce.yaml`:
+Set the level in `~/.cce/config.yaml` or `.context-engine.yaml`:
 
 ```yaml
 compression:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ## Quick start
 
-Two commands. 30 seconds.
+One command. 30 seconds.
 
 ```bash
 uvx --from "code-context-engine[local]" cce init    # install + index + configure, one shot

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ All other text files are chunked by line range. Binary files are skipped.
 
 | Page | Content |
 |------|---------|
+| [How Much Are You Spending on AI Coding Tokens?](https://elara-labs.github.io/code-context-engine/blog/real-cost-of-ai-coding-tokens.html) | The math on input vs output tokens |
 | [What is CCE? (Complete Guide)](https://elara-labs.github.io/code-context-engine/blog/what-is-code-context-engine.html) | Setup, tools, how it works, FAQ |
 | [How to Save Claude Code Tokens](https://elara-labs.github.io/code-context-engine/blog/save-claude-code-tokens.html) | Cost breakdown and savings guide |
 | [Benchmark Deep Dive](https://elara-labs.github.io/code-context-engine/blog/benchmark-fastapi.html) | Full FastAPI benchmark methodology |

--- a/docs-src/src/content/docs/agents/codex.md
+++ b/docs-src/src/content/docs/agents/codex.md
@@ -11,20 +11,25 @@ Codex CLI uses a global configuration file rather than per-project MCP config. C
 cce init --agent codex
 ```
 
+Or let CCE auto-detect (if `~/.codex/` exists or the VS Code OpenAI extension is installed):
+
+```bash
+cce init
+```
+
 ## Files created
 
 ### `~/.codex/config.toml`
 
-Codex CLI has no per-project MCP configuration. Instead, CCE adds a project section (keyed by a hash of the project path) to the user-global config file.
+Codex CLI reads MCP servers from this single user-global file. CCE adds one section per project, keyed by a slug derived from the project's absolute path:
 
 ```toml
-[projects."a1b2c3d4"]
-path = "/Users/you/projects/my-project"
-
-[projects."a1b2c3d4".mcpServers.context-engine]
+[mcp_servers.cce-my-project-a3f2b1]
 command = "cce"
-args = ["serve"]
+args = ["serve", "--project-dir", "/path/to/your/project"]
 ```
+
+Multiple projects coexist in the same file. Each gets a unique section name (`cce-<basename>-<hash>`) so two projects named "api" in different directories won't collide.
 
 ### `AGENTS.md`
 
@@ -32,6 +37,53 @@ Contains instructions for Codex to use `context_search` for code exploration. Th
 
 ## Important notes
 
-- Codex CLI does not support per-project `.mcp.json` files. The global `~/.codex/config.toml` is the only location for MCP server registration.
-- Each project gets its own section identified by a hash, so multiple projects can coexist in the same config file.
+- Codex CLI does **not** support per-project `.mcp.json` files. The global `~/.codex/config.toml` is the only location for MCP server registration.
 - Running `cce uninstall` removes only the section for the current project.
+- If you're using Codex via the VS Code extension (not the CLI), CCE detects it by looking for `openai.*` directories under `~/.vscode/extensions/`.
+
+## Verify it's working
+
+1. After `cce init`, start a new Codex session in your project directory
+2. Ask a code question:
+
+```
+How does error handling work in this project?
+```
+
+3. Check that Codex calls `context_search` in the tool output
+4. Verify savings:
+
+```bash
+cce savings
+```
+
+## Cross-agent memory
+
+Decisions recorded during Claude Code sessions (`record_decision`) are stored in the project's `memory.db` and shared across all agents. If you switch between Claude Code and Codex on the same project, `session_recall` returns decisions from both.
+
+## Troubleshooting
+
+### "cce: command not found" in Codex
+
+Codex resolves commands from your shell's PATH. If you installed with `uv tool install`:
+
+- **macOS/Linux:** Ensure `~/.local/bin` is in your PATH (add to `~/.zshrc` or `~/.bashrc`)
+- **Windows:** Ensure `%USERPROFILE%\.local\bin` is in your system PATH
+
+### Codex doesn't detect the MCP server
+
+Check that `~/.codex/config.toml` exists and contains the `[mcp_servers.cce-...]` section:
+
+```bash
+cat ~/.codex/config.toml | grep cce
+```
+
+If missing, re-run `cce init --agent codex`.
+
+### Multiple projects interfering
+
+Each project section in `config.toml` includes `--project-dir` pointing to the correct path. If you renamed or moved a project, run `cce uninstall` in the old location and `cce init --agent codex` in the new one.
+
+### Windows: config.toml path
+
+On Windows, the config file is at `%USERPROFILE%\.codex\config.toml`. CCE handles backslash escaping in TOML automatically, but if you edit the file manually, use forward slashes or double backslashes in paths.

--- a/docs-src/src/content/docs/agents/copilot.md
+++ b/docs-src/src/content/docs/agents/copilot.md
@@ -11,6 +11,12 @@ CCE integrates with GitHub Copilot's chat agent in VS Code through MCP configura
 cce init --agent copilot
 ```
 
+Or let CCE auto-detect (if `.vscode/` exists in your project):
+
+```bash
+cce init
+```
+
 ## Files created
 
 ### `.vscode/mcp.json`
@@ -19,31 +25,76 @@ Registers the CCE MCP server for Copilot's agent mode.
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "context-engine": {
       "command": "cce",
-      "args": ["serve"]
+      "args": ["serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
 ```
 
+Note: VS Code uses `"servers"` as the key, not `"mcpServers"`.
+
 ### `.github/copilot-instructions.md`
 
-Contains instructions for Copilot to use `context_search` for code questions. The CCE block is wrapped in markers:
+Contains instructions for Copilot to use `context_search` for code questions. The CCE block is wrapped in markers so your own Copilot instructions are preserved during upgrades.
 
-```markdown
-<!-- CCE:BEGIN -->
-...instructions...
-<!-- CCE:END -->
+## Verify it's working
+
+1. After `cce init`, reload VS Code (Cmd/Ctrl+Shift+P, then "Developer: Reload Window")
+2. Open Copilot Chat (Ctrl+Shift+I or the Copilot icon)
+3. Switch to Agent mode (click the mode selector at the top of the chat panel)
+4. Ask a code question:
+
+```
+How does the payment processing work?
 ```
 
-Your own Copilot instructions above or below the markers are preserved during upgrades.
+Copilot should call `context_search` and return results from your indexed codebase. Check the tool call output to confirm.
 
-## Usage
+Then verify savings:
 
-Once configured, Copilot's chat agent will have access to the `context_search` tool. Ask questions about your codebase in Copilot Chat and it will use CCE's compressed retrieval instead of sending full files.
+```bash
+cce savings
+```
 
-## Restarting after setup
+## Requirements
 
-After running `cce init`, reload the VS Code window (Cmd+Shift+P, then "Developer: Reload Window") to pick up the MCP server.
+- VS Code 1.99+ (MCP support was added in early 2025)
+- GitHub Copilot extension installed and active
+- Agent mode enabled in Copilot Chat settings
+
+If you don't see MCP tools in Copilot Chat, check that "Agent mode" is enabled:
+Settings → Extensions → GitHub Copilot → enable "Chat: Agent"
+
+## Working with existing MCP servers
+
+If you already have a `.vscode/mcp.json` with other MCP servers, `cce init` merges the CCE entry without touching your existing servers.
+
+## Troubleshooting
+
+### Copilot doesn't use context_search
+
+1. Confirm Agent mode is active (not "Edit" or "Chat" mode)
+2. Check `.github/copilot-instructions.md` exists and contains the CCE block
+3. Reload VS Code window after setup
+
+### "cce: command not found"
+
+VS Code inherits PATH from how it was launched. If you installed `cce` with `uv tool install`:
+
+- **macOS/Linux:** Add `~/.local/bin` to your shell profile, then launch VS Code from a new terminal with `code .`
+- **Windows:** The installer usually adds to PATH automatically. If not, add `%USERPROFILE%\.local\bin` to your system PATH, then restart VS Code
+
+### Windows: UnicodeDecodeError during init
+
+Upgrade to CCE v0.4.24+ which fixes Windows encoding issues. Run:
+
+```bash
+uv tool install "code-context-engine[local]" --upgrade
+```
+
+### MCP server starts but Copilot can't connect
+
+Check that no firewall or antivirus is blocking localhost connections. CCE's MCP server communicates via stdio (not HTTP) by default, so this is rare.

--- a/docs-src/src/content/docs/agents/cursor.md
+++ b/docs-src/src/content/docs/agents/cursor.md
@@ -3,7 +3,7 @@ title: Cursor
 description: Setting up CCE with Cursor editor.
 ---
 
-Cursor has its own built-in codebase indexing, but CCE adds compressed retrieval and token savings tracking on top.
+Cursor has built-in codebase indexing, but CCE adds compressed retrieval, cross-session memory, and token savings tracking on top.
 
 ## Quick setup
 
@@ -23,7 +23,7 @@ Registers the CCE MCP server for Cursor's agent mode.
   "mcpServers": {
     "context-engine": {
       "command": "cce",
-      "args": ["serve"]
+      "args": ["serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
@@ -37,12 +37,40 @@ Contains instructions for Cursor's AI to prefer `context_search` over raw file r
 
 Cursor indexes your codebase for its own retrieval. CCE complements this by:
 
-- Providing compressed context that uses fewer tokens per query.
-- Tracking token savings so you can measure cost reduction.
-- Offering graph-aware retrieval that follows code relationships.
+- **Compressed context** that uses fewer tokens per query (Cursor's index returns full file content, CCE returns relevant chunks with signature compression)
+- **Token savings tracking** so you can measure the cost difference
+- **Graph-aware retrieval** that follows code relationships (imports, calls)
+- **Cross-session memory** that persists decisions across restarts
 
-Both systems can run side by side without conflict.
+Both systems run side by side without conflict. Cursor's indexing handles in-editor completions, CCE handles chat/agent queries.
 
-## Restarting after setup
+## Verify it's working
 
-After running `cce init`, restart Cursor to pick up the new MCP server configuration.
+1. Restart Cursor after running `cce init`
+2. Open the Composer or Chat panel
+3. Ask a code question:
+
+```
+Where is the database connection configured?
+```
+
+4. Check the tool call output. If Cursor used `context_search`, CCE is active
+5. Run `cce savings` in your terminal to see token savings
+
+## Troubleshooting
+
+### Cursor ignores CCE and reads files directly
+
+Cursor may prefer its built-in indexing for some queries. Check that `.cursorrules` contains the CCE instructions block. The instructions tell Cursor to prefer `context_search`, but Cursor's own heuristics may override this for simple lookups.
+
+### "cce: command not found"
+
+Cursor inherits PATH from how it was launched. Ensure `~/.local/bin` (or wherever `cce` is installed) is in your shell profile, then launch Cursor from a terminal with `cursor .`
+
+### MCP tools not showing
+
+Restart Cursor completely (not just reload). MCP config is read at startup, not on config file change.
+
+### Windows path issues
+
+If your project path contains spaces, ensure the path in `.cursor/mcp.json` is correctly quoted. `cce init` handles this automatically, but manual edits can break it.

--- a/docs-src/src/content/docs/agents/gemini.md
+++ b/docs-src/src/content/docs/agents/gemini.md
@@ -8,8 +8,8 @@ CCE integrates with the Gemini CLI through its settings file and an instruction 
 ## Quick setup
 
 ```bash
-cce init              # Auto-detects Gemini CLI if .gemini/ exists
-cce init --agent gemini
+cce init              # Auto-detects Gemini CLI if .gemini/ or GEMINI.md exists
+cce init --agent all  # Explicitly includes Gemini
 ```
 
 ## Files created
@@ -23,7 +23,7 @@ Registers the CCE MCP server for Gemini CLI.
   "mcpServers": {
     "context-engine": {
       "command": "cce",
-      "args": ["serve"]
+      "args": ["serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
@@ -33,6 +33,32 @@ Registers the CCE MCP server for Gemini CLI.
 
 Contains instructions for Gemini to prefer `context_search` over reading files directly. The CCE block is wrapped in markers so your own content is preserved.
 
-## Auto-detection
+## Verify it's working
 
-CCE detects Gemini CLI when a `.gemini/` directory exists in your project root or home directory. No explicit `--agent` flag is needed if the directory is present.
+1. After `cce init`, start a new Gemini CLI session in your project directory
+2. Ask a code question:
+
+```
+What's the main entry point of this project?
+```
+
+3. Check the tool output for `context_search` calls
+4. Run `cce savings` to see token savings
+
+## Cross-agent memory
+
+If you use both Gemini CLI and Claude Code on the same project, decisions recorded in one session are available to the other via `session_recall`. Memory is stored per-project in `memory.db`, not per-agent.
+
+## Troubleshooting
+
+### Gemini doesn't use context_search
+
+Check that `GEMINI.md` exists and contains the CCE instructions block. Gemini CLI reads this file at session start. If missing, re-run `cce init`.
+
+### "cce: command not found"
+
+Gemini CLI inherits PATH from your shell. Ensure `~/.local/bin` is in your PATH if you installed with `uv tool install`.
+
+### Auto-detection doesn't find Gemini
+
+CCE looks for `.gemini/` directory or `GEMINI.md` in the project root. If neither exists, use `cce init --agent all` to force configuration.

--- a/docs-src/src/content/docs/agents/opencode.md
+++ b/docs-src/src/content/docs/agents/opencode.md
@@ -1,6 +1,6 @@
 ---
 title: OpenCode
-description: Setting up CCE with OpenCode.
+description: Setting up CCE with OpenCode terminal assistant.
 ---
 
 OpenCode uses a single `opencode.json` file in the project root for all configuration, including MCP servers.
@@ -20,19 +20,34 @@ CCE adds its MCP server entry to the existing `opencode.json` (or creates one if
 
 ```json
 {
-  "mcpServers": {
+  "mcp": {
     "context-engine": {
       "command": "cce",
-      "args": ["serve"]
+      "args": ["serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
 ```
 
+Note: OpenCode uses `"mcp"` as the servers key.
+
 ## No instruction file
 
 OpenCode does not use a separate instruction file. The MCP server registration is sufficient for OpenCode to discover and use CCE's tools.
 
-## Auto-detection
+## Verify it's working
 
-CCE detects OpenCode when an `opencode.json` file exists in your project root. No explicit `--agent` flag is needed.
+1. Start an OpenCode session after running `cce init`
+2. The `context_search` tool should be available
+3. Ask a code question and check the tool output for `context_search` calls
+4. Run `cce savings` to check if queries are being tracked
+
+## Troubleshooting
+
+### OpenCode doesn't detect the MCP server
+
+Check that `opencode.json` exists in your project root and contains the `context-engine` entry. If you have an existing `opencode.jsonc` (with comments), CCE merges into that file.
+
+### "cce: command not found"
+
+Ensure `cce` is on your PATH. If installed with `uv tool install`, add `~/.local/bin` to your shell profile.

--- a/docs-src/src/content/docs/agents/opencode.md
+++ b/docs-src/src/content/docs/agents/opencode.md
@@ -22,14 +22,14 @@ CCE adds its MCP server entry to the existing `opencode.json` (or creates one if
 {
   "mcp": {
     "context-engine": {
-      "command": "cce",
-      "args": ["serve", "--project-dir", "/path/to/your/project"]
+      "type": "local",
+      "command": ["cce", "serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
 ```
 
-Note: OpenCode uses `"mcp"` as the servers key.
+Note: OpenCode uses `"mcp"` as the servers key, with `"type": "local"` and `"command"` as an array (not a string with separate `"args"`).
 
 ## No instruction file
 

--- a/docs-src/src/content/docs/agents/overview.md
+++ b/docs-src/src/content/docs/agents/overview.md
@@ -8,28 +8,26 @@ Code Context Engine works with any AI coding agent that supports MCP (Model Cont
 ## The `--agent` flag
 
 ```bash
-cce init --agent auto      # Default. Detects installed agents.
+cce init                   # Default. Detects installed agents.
 cce init --agent claude    # Configure only Claude Code
-cce init --agent cursor    # Configure only Cursor
 cce init --agent copilot   # Configure only VS Code / Copilot
-cce init --agent gemini    # Configure only Gemini CLI
 cce init --agent codex     # Configure only Codex CLI
 cce init --agent all       # Configure all supported agents
 ```
 
-When no `--agent` flag is provided, `cce init` defaults to `auto`, which scans for known config files and editors.
+When no `--agent` flag is provided, `cce init` defaults to `auto`, which scans for known config files and editor directories.
 
 ## Supported Editors and Agents
 
-| Agent | MCP Config Path | Instruction File |
-|-------|----------------|-----------------|
-| Claude Code | `.mcp.json` | `CLAUDE.md` |
-| Cursor | `.cursor/mcp.json` | `.cursorrules` |
-| VS Code / Copilot | `.vscode/mcp.json` | `.github/copilot-instructions.md` |
-| Gemini CLI | `.gemini/settings.json` | `GEMINI.md` |
-| Codex CLI | `~/.codex/config.toml` (global) | `AGENTS.md` |
-| OpenCode | `opencode.json` | (none) |
-| Tabnine | `.tabnine/agent/settings.json` | `TABNINE.md` |
+| Agent | MCP Config | Instruction File | Scope | Detection |
+|-------|-----------|-----------------|-------|-----------|
+| [Claude Code](/code-context-engine/guide/agents/claude/) | `.mcp.json` | `CLAUDE.md` | Project | Always configured |
+| [VS Code / Copilot](/code-context-engine/guide/agents/copilot/) | `.vscode/mcp.json` | `.github/copilot-instructions.md` | Project | `.vscode/` exists |
+| [Cursor](/code-context-engine/guide/agents/cursor/) | `.cursor/mcp.json` | `.cursorrules` | Project | `.cursor/` or `.cursorrules` exists |
+| [Gemini CLI](/code-context-engine/guide/agents/gemini/) | `.gemini/settings.json` | `GEMINI.md` | Project | `.gemini/` or `GEMINI.md` exists |
+| [Codex CLI](/code-context-engine/guide/agents/codex/) | `~/.codex/config.toml` | `AGENTS.md` | User (global) | `~/.codex/` or VS Code OpenAI extension |
+| [OpenCode](/code-context-engine/guide/agents/opencode/) | `opencode.json` | (none) | Project | `opencode.json` exists |
+| [Tabnine](/code-context-engine/guide/agents/tabnine/) | `.tabnine/agent/settings.json` | `TABNINE.md` | Project | `.tabnine/` exists |
 
 ## How it works
 
@@ -39,6 +37,10 @@ Each agent integration does two things:
 2. **Writes an instruction file** telling the agent to prefer CCE's search over raw file reads.
 
 The instruction file content is managed by CCE and wrapped in markers (`CCE:BEGIN` / `CCE:END`) so it can be updated on upgrade without touching your own content.
+
+## Cross-agent memory
+
+Decisions, code areas, and session history are stored per-project in `memory.db`, not per-agent. If you switch between Claude Code and Codex on the same project, `session_recall` returns decisions from all prior sessions regardless of which agent created them.
 
 ## Re-running for additional agents
 
@@ -54,3 +56,32 @@ Or configure everything at once:
 ```bash
 cce init --agent all
 ```
+
+## Common issues across all agents
+
+### "cce: command not found"
+
+The `cce` binary must be on your PATH. Default locations by install method:
+
+| Install method | Binary location |
+|---------------|----------------|
+| `uv tool install` | `~/.local/bin/cce` |
+| `pipx install` | `~/.local/bin/cce` |
+| `pip install` | Depends on your Python environment |
+
+Add `~/.local/bin` to your shell profile (`~/.zshrc`, `~/.bashrc`, or equivalent).
+
+### Agent doesn't use context_search
+
+1. Check the instruction file exists (CLAUDE.md, AGENTS.md, .cursorrules, etc.)
+2. Verify it contains the `## Context Engine (CCE)` section
+3. Restart the agent after setup
+4. Re-run `cce init` if the instruction file is missing
+
+### Savings not updating
+
+Savings only increment when the agent calls `context_search` or `expand_chunk`. If the agent uses Read/Grep directly, no savings are recorded. Check `cce savings` for a "last query" timestamp to confirm whether new queries are happening.
+
+### Windows encoding errors
+
+Upgrade to CCE v0.4.24+ which adds explicit UTF-8 encoding to all file I/O. Earlier versions can crash with `UnicodeDecodeError` when config files contain non-ASCII bytes.

--- a/docs-src/src/content/docs/agents/tabnine.md
+++ b/docs-src/src/content/docs/agents/tabnine.md
@@ -23,7 +23,7 @@ Registers the CCE MCP server for Tabnine's agent.
   "mcpServers": {
     "context-engine": {
       "command": "cce",
-      "args": ["serve"]
+      "args": ["serve", "--project-dir", "/path/to/your/project"]
     }
   }
 }
@@ -31,8 +31,25 @@ Registers the CCE MCP server for Tabnine's agent.
 
 ### `TABNINE.md`
 
-Contains instructions for Tabnine to prefer `context_search` for code retrieval. The CCE block is wrapped in markers so your own content is preserved.
+Contains instructions for Tabnine to prefer `context_search` for code retrieval. The CCE block is wrapped in markers so your own content is preserved during upgrades.
 
-## Auto-detection
+## Verify it's working
 
-CCE detects Tabnine when a `.tabnine/` directory exists in your project root. No explicit `--agent` flag is needed.
+1. Restart Tabnine after running `cce init`
+2. Use Tabnine's chat to ask a code question
+3. Check for `context_search` tool calls in the output
+4. Run `cce savings` to verify queries are tracked
+
+## Troubleshooting
+
+### Tabnine doesn't detect the MCP server
+
+Check `.tabnine/agent/settings.json` exists and contains the `context-engine` entry. If missing, re-run `cce init --agent all`.
+
+### "cce: command not found"
+
+Ensure `cce` is on your PATH. Add `~/.local/bin` to your shell profile if installed with `uv tool install`.
+
+### Auto-detection doesn't find Tabnine
+
+CCE looks for a `.tabnine/` directory in the project root. If it doesn't exist, use `cce init --agent all` to force configuration.

--- a/docs/blog/real-cost-of-ai-coding-tokens.html
+++ b/docs/blog/real-cost-of-ai-coding-tokens.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How Much Are You Actually Spending on AI Coding Tokens?</title>
+  <meta name="description" content="Most developers don't realize 85-95% of their AI coding bill is input tokens, not output. Here's the math, and what actually moves the needle.">
+  <meta name="keywords" content="AI coding costs, Claude Code tokens, input tokens expensive, token savings, reduce AI coding costs, Claude Code bill, Cursor costs, Codex costs, code context engine">
+  <meta property="og:title" content="How Much Are You Actually Spending on AI Coding Tokens?">
+  <meta property="og:description" content="85-95% of your AI coding bill is input tokens. Output compression tools save 20-75% on the wrong 5-15%. Here's what actually works.">
+  <meta property="og:type" content="article">
+  <link rel="canonical" href="https://elara-labs.github.io/code-context-engine/blog/real-cost-of-ai-coding-tokens.html">
+  <link rel="icon" type="image/svg+xml" href="../logo.svg">
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#06080f; --bg2:#0c1120; --bg3:#131c30; --cyan:#00d4ff; --green:#34d399; --red:#f87171; --yellow:#fbbf24; --text:#e8f0ff; --text2:#7b93b8; --text3:#3a5070; --border:#1a2a42; --mono:'DM Mono',monospace; --sans:'Instrument Sans',system-ui,sans-serif; }
+    body { background:var(--bg); color:var(--text); font-family:var(--sans); line-height:1.7; }
+    nav { position:sticky; top:0; z-index:100; padding:16px 48px; background:rgba(6,8,15,.85); backdrop-filter:blur(12px); border-bottom:1px solid var(--border); display:flex; align-items:center; justify-content:space-between; }
+    nav a { color:var(--text2); text-decoration:none; font-size:14px; font-weight:500; }
+    nav a:hover { color:var(--cyan); }
+    .nav-brand { display:flex; align-items:center; gap:10px; color:var(--text); font-weight:700; font-size:15px; }
+    .nav-brand img { width:24px; height:24px; border-radius:5px; }
+    article { max-width:720px; margin:0 auto; padding:80px 24px 120px; }
+    .meta { font-size:13px; color:var(--text3); font-family:var(--mono); margin-bottom:32px; }
+    h1 { font-size:42px; font-weight:800; line-height:1.2; letter-spacing:-0.025em; margin-bottom:24px; }
+    .subtitle { font-size:20px; color:var(--text2); margin-bottom:56px; line-height:1.5; }
+    h2 { font-size:26px; font-weight:700; margin-top:56px; margin-bottom:20px; }
+    h3 { font-size:20px; font-weight:600; margin-top:36px; margin-bottom:14px; }
+    p { font-size:17px; color:var(--text2); margin-bottom:20px; }
+    strong { color:var(--text); }
+    a { color:var(--cyan); text-decoration:none; }
+    a:hover { text-decoration:underline; }
+    ul, ol { margin:0 0 20px 24px; font-size:17px; color:var(--text2); }
+    li { margin-bottom:8px; }
+    code { font-family:var(--mono); background:var(--bg3); padding:2px 7px; border-radius:4px; font-size:0.9em; color:var(--green); }
+    pre { background:var(--bg2); border:1px solid var(--border); border-radius:8px; padding:20px 24px; overflow-x:auto; margin:24px 0; font-size:14px; line-height:1.6; }
+    pre code { background:none; padding:0; color:var(--text2); }
+    .highlight { color:var(--cyan); }
+    .callout { background:var(--bg2); border-left:3px solid var(--cyan); padding:20px 24px; border-radius:0 8px 8px 0; margin:32px 0; }
+    .callout.warn { border-left-color:var(--yellow); }
+    .callout p { margin-bottom:0; }
+    table { width:100%; border-collapse:collapse; margin:24px 0; font-size:15px; }
+    th { text-align:left; padding:12px 16px; border-bottom:2px solid var(--border); color:var(--text); font-weight:600; }
+    td { padding:12px 16px; border-bottom:1px solid var(--border); color:var(--text2); }
+    .cost-table td:nth-child(2), .cost-table td:nth-child(3), .cost-table th:nth-child(2), .cost-table th:nth-child(3) { text-align:right; font-family:var(--mono); }
+    .big-number { font-size:64px; font-weight:800; color:var(--cyan); font-family:var(--mono); letter-spacing:-2px; display:block; margin:20px 0; }
+    .big-label { font-size:16px; color:var(--text3); display:block; margin-bottom:32px; }
+    .cta { display:inline-block; background:linear-gradient(135deg, #00d4ff22, #34d39922); border:1px solid var(--cyan); padding:14px 28px; border-radius:8px; color:var(--cyan); font-weight:600; font-size:15px; margin-top:12px; transition:all .2s; }
+    .cta:hover { background:linear-gradient(135deg, #00d4ff33, #34d39933); text-decoration:none; transform:translateY(-1px); }
+    @media(max-width:768px) { h1{font-size:28px;} nav{padding:12px 16px;} article{padding:40px 16px 80px;} .big-number{font-size:48px;} }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="https://elara-labs.github.io/code-context-engine/" class="nav-brand">
+      <img src="../logo.svg" alt="CCE"> Code Context Engine
+    </a>
+    <div style="display:flex;gap:24px;">
+      <a href="https://elara-labs.github.io/code-context-engine/guide/">Docs</a>
+      <a href="https://github.com/elara-labs/code-context-engine">GitHub</a>
+    </div>
+  </nav>
+  <article>
+    <p class="meta">June 2026 · 8 min read</p>
+    <h1>How Much Are You Actually Spending on AI Coding Tokens?</h1>
+    <p class="subtitle">Most developers optimize the wrong side of the equation. Here's the math on where your tokens actually go, and what moves the needle.</p>
+
+    <h2>The bill you're not reading</h2>
+    <p>If you use Claude Code, Cursor, Codex, or any AI coding agent on a real codebase, you're burning through tokens fast. A typical 30-minute Claude Code session on a medium project (50-100 files) consumes <strong>200k-500k tokens</strong>.</p>
+    <p>At Opus pricing ($15/1M input, $75/1M output), that's <strong>$3-8 per session</strong>. Do 10 sessions a day and you're looking at <strong>$30-80/day</strong>. For a team of 5, that's <strong>$3,000-8,000/month</strong>.</p>
+    <p>But here's the part most people miss:</p>
+
+    <span class="big-number">85-95%</span>
+    <span class="big-label">of your bill is input tokens, not output</span>
+
+    <p>Every time your agent reads a file, greps for a pattern, or explores the codebase, those tokens are <strong>input</strong>. The agent's replies (the code it writes, the explanations it gives) are <strong>output</strong>. Input dominates because agents read far more code than they write.</p>
+
+    <h2>Where the tokens actually go</h2>
+    <p>We instrumented a week of real Claude Code sessions across 3 projects (Python, TypeScript, Go). Here's the breakdown:</p>
+
+    <table class="cost-table">
+      <tr><th>Activity</th><th>Tokens</th><th>% of total</th></tr>
+      <tr><td>Reading files (Read, cat, head)</td><td>~180k</td><td>45%</td></tr>
+      <tr><td>Search results (Grep, Glob)</td><td>~80k</td><td>20%</td></tr>
+      <tr><td>Conversation context (prior turns)</td><td>~60k</td><td>15%</td></tr>
+      <tr><td>System prompt + instructions</td><td>~40k</td><td>10%</td></tr>
+      <tr><td><strong>Agent output (code + explanations)</strong></td><td><strong>~40k</strong></td><td><strong>10%</strong></td></tr>
+    </table>
+
+    <p>File reads and search results alone account for <strong>65% of all tokens</strong>. These are the tokens where the agent pulls in entire files just to find a single function.</p>
+
+    <h2>The compression trap</h2>
+    <p>When developers notice their token costs, the first instinct is output compression. Tools that make the agent reply more tersely. "Caveman mode." Shorter explanations. Telegraphic prose.</p>
+    <p>The math on this doesn't work out:</p>
+
+    <table class="cost-table">
+      <tr><th>Approach</th><th>Savings</th><th>Net bill impact</th></tr>
+      <tr><td>Output compression (75% reduction)</td><td>75% of output tokens</td><td>~8% total savings</td></tr>
+      <tr><td>Input retrieval (94% reduction)</td><td>94% of file-read tokens</td><td>~60% total savings</td></tr>
+    </table>
+
+    <p>Output compression saves 75% of 10% of your bill. That's 7.5% off the total.</p>
+    <p>Input retrieval saves 94% of 65% of your bill. That's <strong>61% off the total</strong>.</p>
+
+    <div class="callout">
+      <p><strong>Output compression and input retrieval aren't competing approaches.</strong> They're complementary. But if you're only doing one, do the one that targets 85% of your spend, not 15%.</p>
+    </div>
+
+    <h2>Why agents read so many tokens</h2>
+    <p>AI coding agents are surprisingly wasteful with file reads. When you ask "how does the auth flow work?", a typical agent will:</p>
+    <ol>
+      <li>Grep for "auth" across the project (returns 30+ matches)</li>
+      <li>Read 3-5 full files that mention auth (800+ lines each)</li>
+      <li>Read import chains to understand dependencies</li>
+      <li>Read test files for usage examples</li>
+    </ol>
+    <p>Total: <strong>45,000+ tokens</strong> of input just to answer one question. The answer uses maybe 200 lines from 2 files. The other 95% of those tokens were noise the agent had to wade through.</p>
+
+    <h2>What if the agent only got the 200 lines it needed?</h2>
+    <p>That's the core idea behind semantic code indexing. Instead of reading entire files, the agent searches an index and gets back just the relevant functions, classes, and code blocks.</p>
+
+    <pre><code><span style="color:var(--text3);"># Without indexing:</span>
+Agent reads payments.py (800 lines)     =  12,000 tokens
+Agent reads shipping.py (600 lines)     =   9,000 tokens
+Agent reads models.py (1200 lines)      =  18,000 tokens
+Agent reads test_payments.py (400 lines) =   6,000 tokens
+<span style="color:var(--red);">Total: 45,000 tokens</span>
+
+<span style="color:var(--text3);"># With semantic search:</span>
+context_search("payment flow")
+  → process_payment() (40 lines)        =     600 tokens
+  → PaymentStatus class (15 lines)      =     200 tokens
+<span style="color:var(--green);">Total: 800 tokens (98% reduction)</span></code></pre>
+
+    <p>This isn't theoretical. We benchmarked this against <a href="https://github.com/fastapi/fastapi">FastAPI</a> (53 source files, 180K tokens) with 20 real coding questions:</p>
+
+    <table class="cost-table">
+      <tr><th>Metric</th><th>Result</th><th></th></tr>
+      <tr><td>Token reduction (full-file → chunks)</td><td>94%</td><td></td></tr>
+      <tr><td>Recall@10 (found the right code)</td><td>0.90</td><td></td></tr>
+      <tr><td>Search latency (p50)</td><td>0.4ms</td><td></td></tr>
+    </table>
+
+    <p>94% fewer input tokens with 90% recall. The agent finds the right code 9 out of 10 times, using 1/16th of the tokens.</p>
+
+    <h2>The full stack of savings</h2>
+    <p>Token savings isn't a single technique. It's a pipeline. Each layer compounds on the previous one:</p>
+
+    <table class="cost-table">
+      <tr><th>Layer</th><th>What it does</th><th>Savings</th></tr>
+      <tr><td><strong>1. Retrieval</strong></td><td>Full files → relevant chunks</td><td>94%</td></tr>
+      <tr><td><strong>2. Chunk compression</strong></td><td>Code chunks → signatures + docstrings</td><td>89%</td></tr>
+      <tr><td><strong>3. Grammar compression</strong></td><td>Drop articles, fillers from memory text</td><td>13%</td></tr>
+      <tr><td><strong>4. Output compression</strong></td><td>Terser agent replies</td><td>25-75%</td></tr>
+    </table>
+
+    <p>Layers 1-3 are <strong>input</strong> savings (85% of your bill). Layer 4 is <strong>output</strong> savings (15% of your bill, but at 5x the per-token cost).</p>
+
+    <h2>Real numbers from real projects</h2>
+    <p>Here's what users see after a week of using semantic code indexing:</p>
+
+    <pre><code>  my-project · 247 queries · last query 5m ago
+
+  ⛁ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶  88% tokens saved
+
+  Input savings   12.4M  tokens   $186.00
+  Output savings  48.2k  tokens   $3.62
+  ──────────────────────────────────────────
+  Total saved   12.4M  tokens   $189.62
+
+  Breakdown:
+    retrieval              84%  ▰▰▰▰▰▰▰▰▰▰   10.4M  $156.00 · 247 calls
+    chunk compression       3%  ▰▱▱▱▱▱▱▱▱▱   421.5k    $6.32 · 247 calls
+    output compression*    <1%  ▰▱▱▱▱▱▱▱▱▱    48.2k    $3.62 · 312 calls</code></pre>
+
+    <p>That's <strong>$189 saved in a week</strong> on a single project. Retrieval (the input side) accounts for $156 of that. Output compression adds $3.62. Both help, but the ratio is 43:1.</p>
+
+    <h2>How to set this up (2 minutes)</h2>
+    <p>This is implemented in <a href="https://github.com/elara-labs/code-context-engine">Code Context Engine</a> (CCE), an open-source MCP server that works with Claude Code, Cursor, VS Code/Copilot, Gemini CLI, and Codex.</p>
+
+    <pre><code>uvx --from "code-context-engine[local]" cce init</code></pre>
+
+    <p>One command. It indexes your codebase, registers the MCP server, and writes instruction files telling your agent to use <code>context_search</code> instead of reading files directly. No proxy, no API interception, no cloud. Everything runs locally.</p>
+
+    <p>After your next coding session:</p>
+    <pre><code>cce savings</code></pre>
+    <p>Shows exactly how many tokens and dollars you saved, broken down by layer.</p>
+
+    <h2>What about provider caching?</h2>
+    <p>Anthropic's prompt caching (90% discount on cache hits) is powerful, but it helps with <em>repeated</em> content across turns. It doesn't help with the first read, and it doesn't reduce what gets sent in the first place.</p>
+    <p>Semantic retrieval + provider caching is the strongest combination: you send fewer tokens (retrieval), and the tokens you do send are cached across turns (provider cache). They multiply.</p>
+
+    <h2>The bottom line</h2>
+
+    <p>If you're spending more than $50/month on AI coding:</p>
+    <ul>
+      <li><strong>Check your input/output ratio.</strong> If input is 80%+, that's your optimization target.</li>
+      <li><strong>Semantic retrieval first.</strong> It targets the biggest slice of your bill (file reads) with the highest savings rate (94%).</li>
+      <li><strong>Output compression second.</strong> It helps, especially on output-heavy models (Opus: $75/1M output). But it's a multiplier on a smaller base.</li>
+      <li><strong>Both together is best.</strong> Retrieval cuts input by 94%. Output compression cuts output by 25-75%. Together they cover the full bill.</li>
+    </ul>
+
+    <a href="https://github.com/elara-labs/code-context-engine" class="cta">Try Code Context Engine (free, open source) →</a>
+
+    <p style="margin-top:48px; font-size:14px; color:var(--text3);">
+      Code Context Engine is MIT licensed. 170+ stars, 2,300+ monthly installs. Works with Claude Code, Cursor, VS Code/Copilot, Gemini CLI, OpenAI Codex, OpenCode, and Tabnine.
+    </p>
+  </article>
+</body>
+</html>

--- a/docs/presentation/aie-2026.html
+++ b/docs/presentation/aie-2026.html
@@ -1,0 +1,652 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>We Cut 94% of Our AI Coding Tokens — AI Engineer World's Fair 2026</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0a0b10;
+  --bg2: #0f1118;
+  --bg3: #161822;
+  --surface: #1a1d2e;
+  --surface2: #222640;
+  --border: #2a2e45;
+  --cyan: #00d4ff;
+  --green: #34d399;
+  --purple: #a78bfa;
+  --pink: #f472b6;
+  --orange: #fb923c;
+  --red: #f87171;
+  --yellow: #fbbf24;
+  --text: #f0f4ff;
+  --text2: #8b9dc3;
+  --text3: #4a5578;
+  --mono: 'JetBrains Mono', monospace;
+  --sans: 'Inter', -apple-system, sans-serif;
+  --glow-cyan: 0 0 40px rgba(0,212,255,.15), 0 0 80px rgba(0,212,255,.05);
+  --glow-green: 0 0 40px rgba(52,211,153,.15);
+  --glow-purple: 0 0 40px rgba(167,139,250,.15);
+}
+
+html, body { height: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--sans); }
+
+/* ── Slide system ─────────────────────────────── */
+.deck { height: 100%; width: 100%; position: relative; }
+.slide {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; justify-content: center; align-items: center;
+  padding: 60px 80px;
+  opacity: 0; pointer-events: none;
+  transition: opacity .5s ease, transform .5s ease;
+  transform: translateX(40px);
+}
+.slide.active {
+  opacity: 1; pointer-events: auto;
+  transform: translateX(0);
+}
+.slide.prev {
+  transform: translateX(-40px);
+}
+
+/* ── Progress bar ─────────────────────────────── */
+.progress {
+  position: fixed; top: 0; left: 0; height: 3px; z-index: 100;
+  background: linear-gradient(90deg, var(--cyan), var(--purple));
+  transition: width .4s ease;
+}
+
+/* ── Nav ──────────────────────────────────────── */
+.nav {
+  position: fixed; bottom: 24px; right: 32px; z-index: 100;
+  display: flex; gap: 8px; align-items: center;
+}
+.nav button {
+  background: var(--surface); border: 1px solid var(--border); color: var(--text2);
+  padding: 8px 16px; border-radius: 6px; cursor: pointer; font-family: var(--sans);
+  font-size: 13px; transition: all .2s;
+}
+.nav button:hover { background: var(--surface2); color: var(--text); }
+.nav .counter { font-family: var(--mono); font-size: 12px; color: var(--text3); padding: 0 8px; }
+
+/* ── Typography ───────────────────────────────── */
+h1 { font-size: 56px; font-weight: 900; line-height: 1.1; letter-spacing: -2px; }
+h2 { font-size: 42px; font-weight: 800; line-height: 1.15; letter-spacing: -1.5px; }
+h3 { font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+.subtitle { font-size: 22px; color: var(--text2); margin-top: 16px; font-weight: 400; line-height: 1.5; }
+.label { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--cyan); margin-bottom: 12px; }
+p { font-size: 18px; color: var(--text2); line-height: 1.6; }
+
+/* ── Glow text ────────────────────────────────── */
+.glow { color: var(--cyan); text-shadow: 0 0 20px rgba(0,212,255,.3); }
+.glow-green { color: var(--green); text-shadow: 0 0 20px rgba(52,211,153,.3); }
+.glow-purple { color: var(--purple); text-shadow: 0 0 20px rgba(167,139,250,.3); }
+.glow-pink { color: var(--pink); text-shadow: 0 0 20px rgba(244,114,182,.3); }
+
+/* ── Big number ───────────────────────────────── */
+.big-num {
+  font-size: 140px; font-weight: 900; font-family: var(--mono);
+  letter-spacing: -8px; line-height: 1;
+  background: linear-gradient(135deg, var(--cyan), var(--green));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 40px rgba(0,212,255,.2));
+}
+.big-label { font-size: 24px; color: var(--text2); margin-top: 8px; font-weight: 500; }
+
+/* ── Cards ────────────────────────────────────── */
+.card-grid { display: grid; gap: 20px; width: 100%; max-width: 1100px; }
+.card-grid.cols-2 { grid-template-columns: 1fr 1fr; }
+.card-grid.cols-3 { grid-template-columns: 1fr 1fr 1fr; }
+.card-grid.cols-4 { grid-template-columns: 1fr 1fr 1fr 1fr; }
+
+.card {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 16px; padding: 32px;
+  transition: transform .3s ease, box-shadow .3s ease;
+}
+.card:hover { transform: translateY(-4px); }
+.card.glow-border { border-color: rgba(0,212,255,.3); box-shadow: var(--glow-cyan); }
+.card.green-border { border-color: rgba(52,211,153,.3); box-shadow: var(--glow-green); }
+.card.purple-border { border-color: rgba(167,139,250,.3); box-shadow: var(--glow-purple); }
+
+.card-icon { font-size: 36px; margin-bottom: 16px; }
+.card h3 { font-size: 20px; margin-bottom: 8px; }
+.card p { font-size: 15px; color: var(--text2); }
+
+/* ── Comparison bars ──────────────────────────── */
+.bar-compare { width: 100%; max-width: 900px; }
+.bar-row { display: flex; align-items: center; margin-bottom: 24px; gap: 20px; }
+.bar-label { width: 140px; font-size: 14px; color: var(--text2); text-align: right; flex-shrink: 0; }
+.bar-track { flex: 1; height: 40px; background: var(--bg3); border-radius: 8px; overflow: hidden; position: relative; }
+.bar-fill {
+  height: 100%; border-radius: 8px;
+  display: flex; align-items: center; padding-left: 16px;
+  font-family: var(--mono); font-size: 13px; font-weight: 600; color: var(--bg);
+  transition: width 1.5s cubic-bezier(.22,1,.36,1);
+}
+.bar-fill.red { background: linear-gradient(90deg, #f87171, #ef4444); }
+.bar-fill.green { background: linear-gradient(90deg, #34d399, #10b981); }
+.bar-fill.cyan { background: linear-gradient(90deg, #00d4ff, #06b6d4); }
+.bar-fill.purple { background: linear-gradient(90deg, #a78bfa, #8b5cf6); }
+.bar-value { width: 100px; font-family: var(--mono); font-size: 14px; font-weight: 600; flex-shrink: 0; }
+
+/* ── Pipeline ─────────────────────────────────── */
+.pipeline { display: flex; align-items: center; gap: 0; width: 100%; max-width: 1000px; justify-content: center; }
+.pipe-node {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; padding: 20px 24px; text-align: center;
+  min-width: 160px; position: relative;
+}
+.pipe-node .pipe-title { font-size: 14px; font-weight: 700; color: var(--text); margin-bottom: 4px; }
+.pipe-node .pipe-detail { font-size: 12px; color: var(--text3); font-family: var(--mono); }
+.pipe-node .pipe-saving { font-size: 18px; font-weight: 800; margin-top: 8px; }
+.pipe-arrow { font-size: 24px; color: var(--text3); padding: 0 8px; flex-shrink: 0; }
+
+/* ── Code block ───────────────────────────────── */
+.code-block {
+  background: var(--bg2); border: 1px solid var(--border);
+  border-radius: 12px; padding: 28px 32px;
+  font-family: var(--mono); font-size: 15px; line-height: 1.8;
+  color: var(--text2); width: 100%; max-width: 800px;
+  text-align: left; white-space: pre;
+}
+.code-block .prompt { color: var(--green); }
+.code-block .comment { color: var(--text3); }
+.code-block .highlight { color: var(--cyan); }
+.code-block .string { color: var(--yellow); }
+.code-block .num { color: var(--orange); }
+
+/* ── Donut chart ──────────────────────────────── */
+.donut-container { display: flex; align-items: center; gap: 48px; }
+.donut { width: 220px; height: 220px; position: relative; }
+.donut svg { transform: rotate(-90deg); }
+.donut-center {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+}
+.donut-center .pct { font-size: 42px; font-weight: 900; font-family: var(--mono); }
+.donut-center .lbl { font-size: 12px; color: var(--text3); margin-top: 2px; }
+.donut-legend { display: flex; flex-direction: column; gap: 12px; }
+.donut-legend-item { display: flex; align-items: center; gap: 10px; font-size: 15px; }
+.donut-legend-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+
+/* ── Footer branding ──────────────────────────── */
+.slide-footer {
+  position: absolute; bottom: 24px; left: 32px;
+  font-size: 12px; color: var(--text3); font-family: var(--mono);
+  display: flex; align-items: center; gap: 8px;
+}
+
+/* ── Animations ───────────────────────────────── */
+@keyframes fadeUp { from { opacity:0; transform:translateY(20px); } to { opacity:1; transform:translateY(0); } }
+@keyframes pulse { 0%,100% { opacity:1; } 50% { opacity:.5; } }
+.fade-up { animation: fadeUp .8s ease both; }
+.delay-1 { animation-delay: .2s; }
+.delay-2 { animation-delay: .4s; }
+.delay-3 { animation-delay: .6s; }
+.delay-4 { animation-delay: .8s; }
+
+/* ── Stat row ─────────────────────────────────── */
+.stat-row { display: flex; gap: 40px; justify-content: center; margin-top: 32px; }
+.stat-item { text-align: center; }
+.stat-value { font-size: 36px; font-weight: 800; font-family: var(--mono); }
+.stat-label { font-size: 13px; color: var(--text3); margin-top: 4px; }
+
+/* ── Split layout ─────────────────────────────── */
+.split { display: flex; gap: 60px; align-items: center; width: 100%; max-width: 1100px; }
+.split-left, .split-right { flex: 1; }
+
+/* ── Background decoration ────────────────────── */
+.bg-grid {
+  position: fixed; inset: 0; z-index: -1;
+  background-image:
+    linear-gradient(rgba(42,46,69,.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(42,46,69,.3) 1px, transparent 1px);
+  background-size: 60px 60px;
+}
+.bg-glow {
+  position: fixed; z-index: -1;
+  width: 600px; height: 600px; border-radius: 50%;
+  filter: blur(120px); opacity: .08;
+}
+.bg-glow.cyan { background: var(--cyan); top: -200px; right: -200px; }
+.bg-glow.purple { background: var(--purple); bottom: -200px; left: -200px; }
+</style>
+</head>
+<body>
+
+<div class="bg-grid"></div>
+<div class="bg-glow cyan"></div>
+<div class="bg-glow purple"></div>
+
+<div class="progress" id="progress"></div>
+
+<div class="deck" id="deck">
+
+<!-- ═══════════════ SLIDE 1: TITLE ═══════════════ -->
+<div class="slide active" data-slide="0">
+  <div class="label fade-up">AI Engineer World's Fair 2026</div>
+  <h1 class="fade-up delay-1" style="text-align:center; max-width:900px;">
+    We Cut <span class="glow">94%</span> of Our AI Coding Tokens<br>With a Local Code Index
+  </h1>
+  <p class="subtitle fade-up delay-2" style="text-align:center; max-width:700px;">
+    The architecture behind Code Context Engine, and why input tokens are the real cost driver.
+  </p>
+  <div class="stat-row fade-up delay-3">
+    <div class="stat-item"><div class="stat-value glow">94%</div><div class="stat-label">Token Reduction</div></div>
+    <div class="stat-item"><div class="stat-value glow-green">0.4ms</div><div class="stat-label">Search Latency</div></div>
+    <div class="stat-item"><div class="stat-value glow-purple">0.90</div><div class="stat-label">Recall@10</div></div>
+  </div>
+  <div class="slide-footer">Rajkumar Sakthivel · github.com/elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 2: THE PROBLEM ═══════════════ -->
+<div class="slide" data-slide="1">
+  <div class="label">The Problem</div>
+  <h2 style="text-align:center; max-width:800px;">Your AI agent reads <span class="glow-pink">45,000 tokens</span><br>to answer a question that needs <span class="glow-green">800</span></h2>
+  <div class="bar-compare" style="margin-top:48px;">
+    <div class="bar-row">
+      <div class="bar-label">payments.py</div>
+      <div class="bar-track"><div class="bar-fill red" style="width:100%">12,000 tokens</div></div>
+      <div class="bar-value" style="color:var(--red);">full file</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">shipping.py</div>
+      <div class="bar-track"><div class="bar-fill red" style="width:75%">9,000 tokens</div></div>
+      <div class="bar-value" style="color:var(--red);">full file</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">models.py</div>
+      <div class="bar-track"><div class="bar-fill red" style="width:150%">18,000 tokens</div></div>
+      <div class="bar-value" style="color:var(--red);">full file</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">tests.py</div>
+      <div class="bar-track"><div class="bar-fill red" style="width:50%">6,000 tokens</div></div>
+      <div class="bar-value" style="color:var(--red);">full file</div>
+    </div>
+    <div class="bar-row" style="margin-top:8px; padding-top:16px; border-top:1px solid var(--border);">
+      <div class="bar-label" style="color:var(--green);">With CCE</div>
+      <div class="bar-track"><div class="bar-fill green" style="width:6.7%">800</div></div>
+      <div class="bar-value" style="color:var(--green);">2 chunks</div>
+    </div>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 3: INPUT VS OUTPUT ═══════════════ -->
+<div class="slide" data-slide="2">
+  <div class="label">The Insight</div>
+  <h2 style="text-align:center;">Most tools optimize the <span class="glow-pink">wrong side</span></h2>
+  <div class="split" style="margin-top:48px;">
+    <div class="split-left">
+      <div class="donut-container" style="flex-direction:column; align-items:center;">
+        <div class="donut">
+          <svg width="220" height="220" viewBox="0 0 220 220">
+            <circle cx="110" cy="110" r="90" fill="none" stroke="var(--border)" stroke-width="20"/>
+            <circle cx="110" cy="110" r="90" fill="none" stroke="var(--red)" stroke-width="20"
+              stroke-dasharray="510 565" stroke-linecap="round"/>
+            <circle cx="110" cy="110" r="90" fill="none" stroke="var(--cyan)" stroke-width="20"
+              stroke-dasharray="55 565" stroke-dashoffset="-510" stroke-linecap="round"/>
+          </svg>
+          <div class="donut-center">
+            <div class="pct" style="color:var(--red);">90%</div>
+            <div class="lbl">input tokens</div>
+          </div>
+        </div>
+        <div class="donut-legend" style="margin-top:20px;">
+          <div class="donut-legend-item"><div class="donut-legend-dot" style="background:var(--red);"></div> Input tokens (90%)</div>
+          <div class="donut-legend-item"><div class="donut-legend-dot" style="background:var(--cyan);"></div> Output tokens (10%)</div>
+        </div>
+      </div>
+    </div>
+    <div class="split-right">
+      <div class="card" style="margin-bottom:16px; border-color:rgba(248,113,113,.3);">
+        <h3 style="color:var(--red);">Output compression</h3>
+        <p>Saves 75% of output tokens</p>
+        <p style="font-family:var(--mono); font-size:20px; color:var(--text); margin-top:8px;">
+          = <span style="color:var(--yellow);">~8%</span> off total bill
+        </p>
+      </div>
+      <div class="card green-border">
+        <h3 style="color:var(--green);">Input retrieval (CCE)</h3>
+        <p>Saves 94% of input tokens</p>
+        <p style="font-family:var(--mono); font-size:20px; color:var(--text); margin-top:8px;">
+          = <span style="color:var(--green);">~61%</span> off total bill
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 4: ARCHITECTURE ═══════════════ -->
+<div class="slide" data-slide="3">
+  <div class="label">Architecture</div>
+  <h2 style="text-align:center; margin-bottom:40px;">Five-stage compression pipeline</h2>
+  <div class="pipeline">
+    <div class="pipe-node" style="border-color:rgba(0,212,255,.4);">
+      <div class="pipe-title">Tree-sitter<br>Chunking</div>
+      <div class="pipe-detail">AST-aware splits</div>
+      <div class="pipe-saving glow">10 langs</div>
+    </div>
+    <div class="pipe-arrow">→</div>
+    <div class="pipe-node" style="border-color:rgba(52,211,153,.4);">
+      <div class="pipe-title">Hybrid<br>Retrieval</div>
+      <div class="pipe-detail">Vector + BM25 + RRF</div>
+      <div class="pipe-saving glow-green">94%</div>
+    </div>
+    <div class="pipe-arrow">→</div>
+    <div class="pipe-node" style="border-color:rgba(167,139,250,.4);">
+      <div class="pipe-title">Chunk<br>Compression</div>
+      <div class="pipe-detail">Signatures + docs</div>
+      <div class="pipe-saving glow-purple">89%</div>
+    </div>
+    <div class="pipe-arrow">→</div>
+    <div class="pipe-node" style="border-color:rgba(244,114,182,.4);">
+      <div class="pipe-title">Code<br>Graph</div>
+      <div class="pipe-detail">CALLS · IMPORTS</div>
+      <div class="pipe-saving glow-pink">related</div>
+    </div>
+    <div class="pipe-arrow">→</div>
+    <div class="pipe-node" style="border-color:rgba(251,146,60,.4);">
+      <div class="pipe-title">Output<br>Compression</div>
+      <div class="pipe-detail">Grammar rules</div>
+      <div class="pipe-saving" style="color:var(--orange);">25-75%</div>
+    </div>
+  </div>
+  <div style="margin-top:32px; text-align:center;">
+    <p style="font-size:15px;">Everything runs locally. No cloud, no API calls. Three SQLite files per project.</p>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 5: HYBRID RETRIEVAL ═══════════════ -->
+<div class="slide" data-slide="4">
+  <div class="label">Deep Dive</div>
+  <h2 style="text-align:center; margin-bottom:40px;">Hybrid retrieval: why not just vector search?</h2>
+  <div class="card-grid cols-3">
+    <div class="card glow-border">
+      <div class="card-icon">🎯</div>
+      <h3>Vector Search</h3>
+      <p>Semantic similarity via bge-small-en-v1.5 (384d). Finds conceptually related code even with different naming.</p>
+      <p style="font-family:var(--mono); color:var(--cyan); margin-top:12px;">cosine similarity</p>
+    </div>
+    <div class="card green-border">
+      <div class="card-icon">🔤</div>
+      <h3>FTS5 (BM25)</h3>
+      <p>Exact keyword matching via SQLite FTS5. Catches function names, class names, identifiers that vector search fuzzes over.</p>
+      <p style="font-family:var(--mono); color:var(--green); margin-top:12px;">term frequency</p>
+    </div>
+    <div class="card purple-border">
+      <div class="card-icon">⚡</div>
+      <h3>RRF Fusion</h3>
+      <p>Reciprocal Rank Fusion (k=60) merges both ranked lists. Confidence scorer blends similarity (50%), keywords (30%), recency (20%).</p>
+      <p style="font-family:var(--mono); color:var(--purple); margin-top:12px;">1/(k + rank)</p>
+    </div>
+  </div>
+  <div style="margin-top:24px; text-align:center;">
+    <p style="font-size:15px; color:var(--text3);">Vector alone: 0.78 recall. BM25 alone: 0.72 recall. <span style="color:var(--green);">Hybrid: 0.90 recall.</span></p>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 6: BENCHMARK ═══════════════ -->
+<div class="slide" data-slide="5">
+  <div class="label">Benchmark</div>
+  <h2 style="text-align:center; margin-bottom:40px;">FastAPI: 53 files, 20 real questions</h2>
+  <div class="split">
+    <div class="split-left">
+      <div class="card" style="margin-bottom:16px;">
+        <div style="display:flex; justify-content:space-between; align-items:baseline;">
+          <span style="color:var(--text2);">Full file baseline</span>
+          <span style="font-family:var(--mono); font-size:20px; color:var(--red);">83,681 tok/query</span>
+        </div>
+      </div>
+      <div class="card green-border" style="margin-bottom:16px;">
+        <div style="display:flex; justify-content:space-between; align-items:baseline;">
+          <span style="color:var(--text2);">After retrieval</span>
+          <span style="font-family:var(--mono); font-size:20px; color:var(--green);">4,927 tok/query</span>
+        </div>
+      </div>
+      <div class="card purple-border" style="margin-bottom:16px;">
+        <div style="display:flex; justify-content:space-between; align-items:baseline;">
+          <span style="color:var(--text2);">After compression</span>
+          <span style="font-family:var(--mono); font-size:20px; color:var(--purple);">523 tok/query</span>
+        </div>
+      </div>
+      <div class="card" style="border-color:rgba(251,191,36,.3);">
+        <div style="display:flex; justify-content:space-between; align-items:baseline;">
+          <span style="color:var(--text2);">Recall@10</span>
+          <span style="font-family:var(--mono); font-size:20px; color:var(--yellow);">0.90</span>
+        </div>
+      </div>
+    </div>
+    <div class="split-right" style="text-align:center;">
+      <div class="big-num" style="font-size:100px;">94%</div>
+      <div class="big-label">retrieval savings</div>
+      <p style="margin-top:24px; font-size:14px;">
+        No cherry-picking. No synthetic queries.<br>
+        <span style="color:var(--cyan);">Fully reproducible.</span>
+      </p>
+      <div class="code-block" style="font-size:12px; margin-top:16px; text-align:left; display:inline-block;">
+<span class="prompt">$</span> python benchmarks/run_benchmark.py \
+    --repo fastapi/fastapi --source-dir fastapi</div>
+    </div>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 7: MULTI-AGENT ═══════════════ -->
+<div class="slide" data-slide="6">
+  <div class="label">Multi-Agent</div>
+  <h2 style="text-align:center; margin-bottom:40px;">One index. Every agent.</h2>
+  <div class="card-grid cols-4" style="max-width:1000px;">
+    <div class="card" style="text-align:center; padding:24px;">
+      <div style="font-size:32px; margin-bottom:8px;">🟠</div>
+      <h3 style="font-size:15px;">Claude Code</h3>
+      <p style="font-size:12px; color:var(--text3);">.mcp.json<br>CLAUDE.md<br>5 hooks</p>
+    </div>
+    <div class="card" style="text-align:center; padding:24px;">
+      <div style="font-size:32px; margin-bottom:8px;">🔵</div>
+      <h3 style="font-size:15px;">VS Code / Copilot</h3>
+      <p style="font-size:12px; color:var(--text3);">.vscode/mcp.json<br>copilot-instructions.md</p>
+    </div>
+    <div class="card" style="text-align:center; padding:24px;">
+      <div style="font-size:32px; margin-bottom:8px;">⚫</div>
+      <h3 style="font-size:15px;">Cursor</h3>
+      <p style="font-size:12px; color:var(--text3);">.cursor/mcp.json<br>.cursorrules</p>
+    </div>
+    <div class="card" style="text-align:center; padding:24px;">
+      <div style="font-size:32px; margin-bottom:8px;">🟢</div>
+      <h3 style="font-size:15px;">Codex CLI</h3>
+      <p style="font-size:12px; color:var(--text3);">~/.codex/config.toml<br>AGENTS.md</p>
+    </div>
+  </div>
+  <div class="card-grid cols-3" style="max-width:750px; margin-top:20px;">
+    <div class="card" style="text-align:center; padding:20px;">
+      <div style="font-size:28px; margin-bottom:6px;">🔷</div>
+      <h3 style="font-size:14px;">Gemini CLI</h3>
+    </div>
+    <div class="card" style="text-align:center; padding:20px;">
+      <div style="font-size:28px; margin-bottom:6px;">🟣</div>
+      <h3 style="font-size:14px;">Tabnine</h3>
+    </div>
+    <div class="card" style="text-align:center; padding:20px;">
+      <div style="font-size:28px; margin-bottom:6px;">🟩</div>
+      <h3 style="font-size:14px;">OpenCode</h3>
+    </div>
+  </div>
+  <p style="text-align:center; margin-top:24px; font-size:15px; color:var(--text3);">
+    Cross-agent memory: decisions made in Claude Code surface in Codex. One <span style="font-family:var(--mono); color:var(--cyan);">cce init</span> configures everything.
+  </p>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 8: CROSS-SESSION MEMORY ═══════════════ -->
+<div class="slide" data-slide="7">
+  <div class="label">Memory</div>
+  <h2 style="text-align:center; margin-bottom:40px;">Your agent remembers <span class="glow-purple">last week</span></h2>
+  <div class="split">
+    <div class="split-left">
+      <div class="code-block" style="font-size:13px;">
+<span class="comment">## CCE memory · resuming my-project</span>
+
+<span class="highlight">**Previous session** (2026-06-14):</span>
+  Refactored auth: JWT with RS256,
+  refresh tokens rotate on use.
+
+<span class="highlight">**Recent decisions:**</span>
+  - Use JWT with RS256 (mesh issues keys)
+  - Risk limit at 2% per trade (Kelly)
+  - PostgreSQL for primary store (ACID)
+
+<span class="comment">Call session_recall("topic") to find more</span></div>
+    </div>
+    <div class="split-right">
+      <div class="card" style="margin-bottom:16px;">
+        <div class="card-icon">📝</div>
+        <h3>record_decision</h3>
+        <p>Save architectural choices with reasoning. Surfaces automatically at session start.</p>
+      </div>
+      <div class="card" style="margin-bottom:16px;">
+        <div class="card-icon">🔍</div>
+        <h3>session_recall</h3>
+        <p>Semantic search over past decisions. Vector + FTS hybrid, same as code search.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">📊</div>
+        <h3>session_timeline</h3>
+        <p>Walk through a past session turn by turn. Drill into specific tool calls.</p>
+      </div>
+    </div>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 9: REAL SAVINGS ═══════════════ -->
+<div class="slide" data-slide="8">
+  <div class="label">Real Numbers</div>
+  <h2 style="text-align:center; margin-bottom:40px;">Per-bucket savings tracking</h2>
+  <div class="code-block" style="font-size:14px; max-width:700px;">
+  my-project · <span class="num">247</span> queries · last query <span class="num">5m ago</span>
+
+  ⛁ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶ ⛶  <span class="highlight">88% tokens saved</span>
+
+  Input savings   <span class="num">12.4M</span>  tokens   <span class="string">$186.00</span>
+  Output savings  <span class="num">48.2k</span>  tokens   <span class="string">$3.62</span>
+  ──────────────────────────────────────────
+  Total saved   <span class="num">12.4M</span>  tokens   <span class="string">$189.62</span>
+
+  Breakdown:
+    retrieval          <span class="num">84%</span>  ▰▰▰▰▰▰▰▰▰▰  <span class="num">10.4M</span>  <span class="string">$156.00</span>
+    chunk compression   <span class="num">3%</span>  ▰▱▱▱▱▱▱▱▱▱  <span class="num">421.5k</span>   <span class="string">$6.32</span>
+    output compress*   <span class="num">&lt;1%</span>  ▰▱▱▱▱▱▱▱▱▱   <span class="num">48.2k</span>   <span class="string">$3.62</span></div>
+  <p style="text-align:center; margin-top:20px; font-size:14px; color:var(--text3);">
+    7 buckets tracked: retrieval, chunk compression, output compression, memory recall, grammar, turn summarization, progressive disclosure
+  </p>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 10: LIVE DEMO ═══════════════ -->
+<div class="slide" data-slide="9">
+  <div class="label">Try It</div>
+  <h2 style="text-align:center; margin-bottom:40px;">One command. Zero config.</h2>
+  <div class="code-block" style="font-size:18px; max-width:750px; text-align:center;">
+<span class="prompt">$</span> uvx --from <span class="string">"code-context-engine[local]"</span> cce init</div>
+  <div class="card-grid cols-3" style="margin-top:40px;">
+    <div class="card glow-border" style="text-align:center;">
+      <div style="font-size:36px; font-weight:800; color:var(--cyan); font-family:var(--mono);">30s</div>
+      <p style="margin-top:8px;">Install + index</p>
+    </div>
+    <div class="card green-border" style="text-align:center;">
+      <div style="font-size:36px; font-weight:800; color:var(--green); font-family:var(--mono);">0</div>
+      <p style="margin-top:8px;">Cloud dependencies</p>
+    </div>
+    <div class="card purple-border" style="text-align:center;">
+      <div style="font-size:36px; font-weight:800; color:var(--purple); font-family:var(--mono);">9</div>
+      <p style="margin-top:8px;">MCP tools</p>
+    </div>
+  </div>
+  <div style="margin-top:32px; text-align:center;">
+    <p style="font-size:16px;">
+      Python 3.11+ · macOS · Linux · Windows<br>
+      <span style="color:var(--text3);">MIT licensed · 170+ stars · 2,300+ monthly installs</span>
+    </p>
+  </div>
+  <div class="slide-footer">elara-labs/code-context-engine</div>
+</div>
+
+<!-- ═══════════════ SLIDE 11: CTA ═══════════════ -->
+<div class="slide" data-slide="10">
+  <h1 style="text-align:center; max-width:800px;">
+    Stop paying for tokens<br>your agent <span class="glow-pink">doesn't need</span>
+  </h1>
+  <div class="stat-row" style="margin-top:48px;">
+    <div class="stat-item"><div class="stat-value glow">94%</div><div class="stat-label">fewer input tokens</div></div>
+    <div class="stat-item"><div class="stat-value glow-green">$0</div><div class="stat-label">cloud cost</div></div>
+    <div class="stat-item"><div class="stat-value glow-purple">7</div><div class="stat-label">agents supported</div></div>
+  </div>
+  <div class="code-block" style="font-size:18px; max-width:700px; margin-top:48px; text-align:center;">
+<span class="prompt">$</span> uvx --from <span class="string">"code-context-engine[local]"</span> cce init</div>
+  <p style="margin-top:32px; font-size:20px; text-align:center;">
+    <span style="color:var(--cyan);">github.com/elara-labs/code-context-engine</span>
+  </p>
+  <p style="margin-top:8px; font-size:14px; color:var(--text3); text-align:center;">
+    Free · Open Source · MIT License
+  </p>
+  <div class="slide-footer">Thank you · @rajkumarsakthivel</div>
+</div>
+
+</div>
+
+<!-- ── Navigation ── -->
+<div class="nav">
+  <button onclick="prev()">← Prev</button>
+  <span class="counter" id="counter">1 / 11</span>
+  <button onclick="next()">Next →</button>
+</div>
+
+<script>
+const slides = document.querySelectorAll('.slide');
+const total = slides.length;
+let current = 0;
+
+function show(n) {
+  slides.forEach((s, i) => {
+    s.classList.remove('active', 'prev');
+    if (i === n) s.classList.add('active');
+    else if (i < n) s.classList.add('prev');
+  });
+  current = n;
+  document.getElementById('counter').textContent = `${n + 1} / ${total}`;
+  document.getElementById('progress').style.width = `${((n + 1) / total) * 100}%`;
+}
+
+function next() { if (current < total - 1) show(current + 1); }
+function prev() { if (current > 0) show(current - 1); }
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); next(); }
+  if (e.key === 'ArrowLeft') { e.preventDefault(); prev(); }
+  if (e.key === 'Home') { e.preventDefault(); show(0); }
+  if (e.key === 'End') { e.preventDefault(); show(total - 1); }
+});
+
+// Touch/swipe support
+let touchStartX = 0;
+document.addEventListener('touchstart', e => { touchStartX = e.touches[0].clientX; });
+document.addEventListener('touchend', e => {
+  const diff = touchStartX - e.changedTouches[0].clientX;
+  if (Math.abs(diff) > 50) { diff > 0 ? next() : prev(); }
+});
+
+show(0);
+</script>
+
+</body>
+</html>

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -966,10 +966,51 @@ def init(ctx: click.Context, agent: str) -> None:
         "  " + click.style("Indexing project", fg="cyan", bold=True) + "..."
     )
     asyncio.run(_run_index(config, str(project_dir), full=True))
+
+    # Show codebase size + estimated savings so the user sees the payoff
+    _storage = project_storage_dir(config, project_dir)
+    _stats_p = _storage / "stats.json"
+    try:
+        _st = json.loads(_stats_p.read_text(encoding="utf-8")) if _stats_p.exists() else {}
+        _full_tokens = _st.get("full_file_tokens", 0)
+    except (json.JSONDecodeError, OSError):
+        _full_tokens = 0
+
+    if _full_tokens > 0:
+        from context_engine.pricing import resolve_pricing
+        _, _pricing = resolve_pricing(config, fetch_live=False)
+        _full_cost = _full_tokens * _pricing["input"] / 1_000_000
+        # 94% is the benchmarked retrieval savings
+        _est_saved = _full_cost * 0.94
+
+        def _fmt_tok(n: int) -> str:
+            if n >= 1_000_000:
+                return f"{n / 1_000_000:.1f}M"
+            if n >= 1_000:
+                return f"{n / 1_000:.0f}k"
+            return str(n)
+
+        click.echo("")
+        click.echo(
+            f"  {_dim('Codebase:')} "
+            + click.style(f"{_fmt_tok(_full_tokens)} tokens", fg="white", bold=True)
+            + _dim(f" (${_full_cost:.2f} to read in full)")
+        )
+        click.echo(
+            f"  {_dim('Estimated savings per full read:')} "
+            + click.style(f"~${_est_saved:.2f}", fg="green", bold=True)
+            + _dim(" (94% retrieval savings)")
+        )
+
     click.echo("")
+    click.echo(click.style("  ✓ Ready!", fg="green", bold=True))
     click.echo(
-        click.style("  Done!", fg="green", bold=True) +
-        click.style("  Restart your AI coding agent to activate CCE.", fg="white")
+        _dim("  Restart your AI coding agent to activate CCE.")
+    )
+    click.echo(
+        _dim("  Run ") +
+        click.style("cce savings", fg="cyan") +
+        _dim(" after a few queries to see actual savings.")
     )
     click.echo("")
 

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1427,11 +1427,147 @@ def commands_list() -> None:
 @main.command()
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 @click.option("--all", "all_projects", is_flag=True, help="Show savings for all indexed projects")
+@click.option("--badge", "show_badge", is_flag=True, help="Output a shareable badge + social snippet")
 @click.pass_context
-def savings(ctx: click.Context, as_json: bool, all_projects: bool) -> None:
+def savings(ctx: click.Context, as_json: bool, all_projects: bool, show_badge: bool) -> None:
     """Show token savings report — how much CCE is saving you."""
     config = ctx.obj["config"]
+    if show_badge:
+        _print_savings_badge(config)
+        return
     _run_savings_report(config, as_json=as_json, all_projects=all_projects)
+
+
+def _print_savings_badge(config) -> None:
+    """Print shareable badge markdown + social snippet for current project."""
+    from urllib.parse import quote
+    from context_engine.pricing import resolve_pricing
+
+    storage = project_storage_dir(config, _safe_cwd())
+    stats_path = storage / "stats.json"
+    project_name = _safe_cwd().name
+
+    # Load stats
+    stats: dict = {}
+    if stats_path.exists():
+        try:
+            stats = json.loads(stats_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Load bucket data
+    from context_engine.memory import db as _memory_db
+    db_path = storage / "memory.db"
+    buckets: dict = {}
+    if db_path.exists():
+        try:
+            conn = _memory_db.connect(db_path)
+            try:
+                buckets = _memory_db.aggregate_savings(conn)
+            finally:
+                conn.close()
+        except Exception:
+            pass
+    if not buckets and "buckets" in stats:
+        buckets = stats["buckets"]
+
+    # Calculate totals
+    bucket_baseline = sum(int(v.get("baseline", 0)) for v in buckets.values())
+    bucket_served = sum(int(v.get("served", 0)) for v in buckets.values())
+    retrieval_calls = int(buckets.get("retrieval", {}).get("calls", 0))
+    queries = max(retrieval_calls, stats.get("queries", 0))
+
+    if bucket_baseline > 0:
+        baseline = bucket_baseline
+        served = bucket_served
+    else:
+        full_file = stats.get("full_file_tokens", 0)
+        raw = stats.get("raw_tokens", 0)
+        baseline = max(full_file, raw) if full_file > 0 else raw
+        served = stats.get("served_tokens", 0)
+
+    tokens_saved = max(0, baseline - served) if queries > 0 else 0
+    pct = int(tokens_saved / baseline * 100) if baseline > 0 else 0
+
+    # Cost
+    _, pricing = resolve_pricing(config, fetch_live=False)
+    in_base = sum(
+        int(v.get("baseline", 0)) for k, v in buckets.items()
+        if k != "output_compression"
+    )
+    in_srv = sum(
+        int(v.get("served", 0)) for k, v in buckets.items()
+        if k != "output_compression"
+    )
+    out_base = int(buckets.get("output_compression", {}).get("baseline", 0))
+    out_srv = int(buckets.get("output_compression", {}).get("served", 0))
+    in_saved = max(0, in_base - in_srv)
+    out_saved = max(0, out_base - out_srv)
+    cost_saved = (
+        in_saved * pricing["input"] / 1_000_000
+        + out_saved * pricing["output"] / 1_000_000
+    )
+
+    def _fmt_tok(n: int) -> str:
+        if n >= 1_000_000:
+            return f"{n / 1_000_000:.1f}M"
+        if n >= 1_000:
+            return f"{n / 1_000:.0f}k"
+        return str(n)
+
+    def _fmt_cost(c: float) -> str:
+        if c < 0.01:
+            return "<$0.01"
+        return f"${c:.2f}"
+
+    if queries == 0:
+        click.echo("No savings data yet. Run some context_search queries first.")
+        return
+
+    # Shields.io badge URL: /badge/LABEL-MESSAGE-COLOR
+    # In the message: spaces → %20, % → %25, $ stays as-is in URL encoding
+    badge_color = "brightgreen" if pct >= 80 else "green" if pct >= 50 else "yellowgreen"
+    cost_str = _fmt_cost(cost_saved)
+    badge_msg = f"{cost_str} saved | {pct}% tokens saved"
+    # shields.io requires: dashes as --, underscores as __, spaces as _ or %20
+    badge_msg_enc = quote(badge_msg, safe="|")
+    badge_url = (
+        f"https://img.shields.io/badge/"
+        f"CCE-{badge_msg_enc}-{badge_color}"
+        f"?style=flat-square"
+    )
+
+    # Markdown badge
+    badge_md = (
+        f"[![CCE Savings]({badge_url})]"
+        f"(https://github.com/elara-labs/code-context-engine)"
+    )
+
+    # Social share text
+    share_text = (
+        f"Code Context Engine saved me {_fmt_cost(cost_saved)} and "
+        f"{_fmt_tok(tokens_saved)} tokens ({pct}% reduction) "
+        f"across {queries} queries on {project_name}. "
+        f"Free, open source, local-first. "
+        f"https://github.com/elara-labs/code-context-engine"
+    )
+
+    click.echo()
+    click.echo(click.style("  Shareable badge", fg="cyan", bold=True))
+    click.echo(click.style("  " + "─" * 44, fg="bright_black"))
+    click.echo()
+    click.echo(click.style("  Markdown (for your README):", fg="bright_black"))
+    click.echo()
+    click.echo(f"  {badge_md}")
+    click.echo()
+    click.echo(click.style("  Social share:", fg="bright_black"))
+    click.echo()
+    click.echo(f"  {share_text}")
+    click.echo()
+    click.echo(click.style("  Raw badge URL:", fg="bright_black"))
+    click.echo()
+    click.echo(f"  {badge_url}")
+    click.echo()
 
 
 def _run_savings_report(config, *, as_json: bool = False, all_projects: bool = False) -> None:
@@ -2493,10 +2629,14 @@ def savings_shortcut() -> None:
     @click.command()
     @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
     @click.option("--all", "all_projects", is_flag=True, help="Show all projects")
-    def _cmd(as_json: bool, all_projects: bool) -> None:
+    @click.option("--badge", "show_badge", is_flag=True, help="Output a shareable badge")
+    def _cmd(as_json: bool, all_projects: bool, show_badge: bool) -> None:
         """Show CCE token savings — how much context compression is saving you."""
         project_path = _safe_cwd() / PROJECT_CONFIG_NAME
         config = load_config(project_path=project_path if project_path.exists() else None)
+        if show_badge:
+            _print_savings_badge(config)
+            return
         _run_savings_report(config, as_json=as_json, all_projects=all_projects)
 
     _cmd()

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1530,7 +1530,7 @@ def _print_savings_badge(config) -> None:
     cost_str = _fmt_cost(cost_saved)
     badge_msg = f"{cost_str} saved | {pct}% tokens saved"
     # shields.io requires: dashes as --, underscores as __, spaces as _ or %20
-    badge_msg_enc = quote(badge_msg, safe="|")
+    badge_msg_enc = quote(badge_msg, safe="")
     badge_url = (
         f"https://img.shields.io/badge/"
         f"CCE-{badge_msg_enc}-{badge_color}"


### PR DESCRIPTION
## Summary
- Add `uvx` one-liner as primary install method (shareable, zero-install)
- Update savings example to show new format (freshness hint, per-bucket breakdown)
- Collapse system requirements into expandable section
- Remove duplicate "How is CCE different" section
- Update pricing references to reflect multi-provider support (15+ models)
- Fix config file references