### PR TITLE
fix: cap tree-sitter<0.26 to stop SIGSEGV/SIGBUS on cce init (#114, #113)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,14 @@ dependencies = [
     "pyyaml>=6.0",
     "sqlite-vec>=0.1.6",
     "numpy>=1.24",
-    "tree-sitter>=0.22",
+    # Cap below 0.26: the tree-sitter 0.26 core changed the Node/Point ABI,
+    # and the tree-sitter-* grammar wheels below are still built against the
+    # 0.25.x ABI. Mixing 0.26 core with 0.25 grammars corrupts memory when
+    # reading Node.start_point/end_point, crashing `cce init` with
+    # SIGSEGV/SIGBUS (issues #113, #114). `uv tool install` resolves this
+    # fresh from PyPI (ignoring uv.lock), so the cap must live here. Lift it
+    # only when all grammar packages ship 0.26-ABI releases.
+    "tree-sitter>=0.22,<0.26",
     "tree-sitter-python>=0.21",
     "tree-sitter-javascript>=0.21",
     "tree-sitter-typescript>=0.21",

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "code-context-engine"
-version = "0.4.20"
+version = "0.4.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -422,7 +422,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
-    { name = "tree-sitter", specifier = ">=0.22" },
+    { name = "tree-sitter", specifier = ">=0.22,<0.26" },
     { name = "tree-sitter-go", specifier = ">=0.23" },
     { name = "tree-sitter-java", specifier = ">=0.23" },
     { name = "tree-sitter-javascript", specifier = ">=0.21" },


### PR DESCRIPTION
## What

Cap `tree-sitter>=0.22,<0.26` in `pyproject.toml` and refresh the `uv.lock` specifier.

Fixes #114. Also fixes #113 (same root cause).

## Why

Both issues report `cce init` crashing with a native signal (SIGSEGV / SIGBUS, exit 138/139) partway through indexing, on macOS arm64. The crash is nondeterministic — the signal and the file being processed vary between runs — which is the fingerprint of **heap corruption**, not a Python-level bug.

Root cause is a **tree-sitter ABI skew**:

- We pin `tree-sitter>=0.22` with no upper bound.
- `uv tool install` / `pip install` ignore `uv.lock` and resolve fresh from PyPI, pulling **tree-sitter 0.26.0 (core)**.
- The `tree-sitter-*` grammar wheels are still built against the **0.25.x ABI**.
- 0.26 changed the `Node`/`Point` struct layout, so reading `Node.start_point`/`end_point` (`chunker.py:77-78`) on a tree parsed by a 0.25 grammar reads a mislaid struct and corrupts the heap. The crash then surfaces downstream at the next native allocation (embedding or the sqlite-vec write), which is why it looks like an embedding/DB crash.

#113 includes a single-threaded, zero-CCE-code repro that crashes on `.start_point` access and is fixed by downgrading to `tree-sitter==0.25.0`. #114's traces confirm embedding itself completes (`305/305 chunks embedded`), ruling out the initial "Python 3.14 native wheel" theory.

The `uv.lock` already resolved core to 0.25.2, so the dev env was never affected — only fresh end-user installs (which bypass the lock). The cap has to live in `pyproject.toml` for that reason.

## Testing

- `core` resolves to `tree-sitter 0.25.2` after the cap.
- Chunker tests pass under Python 3.14 (`pytest tests/indexer -k chunk` → 13 passed).

Lift the cap once all `tree-sitter-*` grammar packages ship 0.26-ABI releases.
