### PR TITLE
fix: thread-local tree-sitter parsers to end concurrent-parse races (#113)

### DIFF
--- a/src/context_engine/indexer/chunker.py
+++ b/src/context_engine/indexer/chunker.py
@@ -1,5 +1,6 @@
 """AST-aware code chunking using tree-sitter."""
 import hashlib
+import threading
 
 import tree_sitter_python as tspython
 import tree_sitter_javascript as tsjavascript
@@ -42,16 +43,29 @@ _LANGUAGES = {
 
 
 class Chunker:
+    # A single Chunker is shared across the indexing run, and the pipeline
+    # fans chunk_with_imports() out over asyncio.to_thread — up to 50 files
+    # of the same language parse concurrently. tree_sitter.Parser holds
+    # mutable C parse state and is documented as unsafe to use from multiple
+    # threads at once; sharing one Parser per language raced on that state
+    # and corrupted memory (SIGSEGV/SIGBUS, issue #113). Parsers are cheap to
+    # build, so cache them per worker thread via threading.local instead —
+    # each thread gets its own Parser and never contends with another.
     def __init__(self) -> None:
-        self._parsers: dict[str, Parser] = {}
+        self._local = threading.local()
 
     def _get_parser(self, language: str) -> Parser | None:
         if language not in _LANGUAGES:
             return None
-        if language not in self._parsers:
+        parsers = getattr(self._local, "parsers", None)
+        if parsers is None:
+            parsers = {}
+            self._local.parsers = parsers
+        parser = parsers.get(language)
+        if parser is None:
             parser = Parser(_LANGUAGES[language])
-            self._parsers[language] = parser
-        return self._parsers[language]
+            parsers[language] = parser
+        return parser
 
     def chunk(self, source: str, file_path: str, language: str) -> list[Chunk]:
         parser = self._get_parser(language)


### PR DESCRIPTION
## What

Cache tree-sitter `Parser` instances in `threading.local` so each worker thread gets its own parser, instead of sharing one `Parser` per language across the whole indexing run.

Addresses the thread-safety half of #113.

## Why

`pipeline._run_indexing_locked` builds a single `chunker = Chunker()` (`pipeline.py:341`) and fans `chunker.chunk_with_imports` out over `asyncio.to_thread`, up to `_BATCH = 50` files at once (`pipeline.py:388`, gathered at the batch loop). Every same-language file then calls `parser.parse()` — twice per file (once in `chunk()`, once in `_extract_imports()`) — on the **same** shared `tree_sitter.Parser` object, with no lock:

```python
# before — one Parser per language, reused across all threads
def __init__(self):
    self._parsers: dict[str, Parser] = {}
```

`tree_sitter.Parser` holds mutable C-level parse state and is documented as unsafe to use concurrently. Concurrent `parse()` calls (and the subsequent `Tree`/`Node` walks, which read parser-backed state) race and corrupt memory, surfacing as nondeterministic SIGSEGV/SIGBUS — the crash reported in #113.

The fix caches parsers per worker thread:

```python
def __init__(self):
    self._local = threading.local()
```

Parsers are cheap to construct, and the indexing thread pool reuses its threads, so per-thread caching keeps full chunking throughput with no locking and no cross-thread contention.

## Relationship to #115

PR #115 caps `tree-sitter<0.26` to remove the 0.26/0.25 **ABI skew** that was the immediate trigger for the crashes in #113/#114. This PR fixes the **latent thread-safety bug** the #113 reporter also flagged ("arguably still good practice since `tree_sitter.Parser` reuse across threads is documented as unsafe"). The two are independent and complementary — the ABI cap stops the current crash; thread-local parsers remove the underlying race so it can't resurface under a future tree-sitter build.

## Testing

- `pytest tests/indexer -k chunk` → 13 passed.
- Stress: shared `Chunker`, 600 tasks across 50 threads (python/js/go) → all parsed, 64000 chunks, no crash.
