### PR TITLE
chore: release v0.4.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "code-context-engine"
-version = "0.4.24"
+version = "0.4.25"
 description = "Save 94% on AI coding tokens. Index your codebase, agents search instead of reading files. Works with Claude Code, Cursor, Codex, Copilot, Gemini CLI. Local MCP server, free, open source."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/elara-labs/code-context-engine",
     "source": "github"
   },
-  "version": "0.4.24",
+  "version": "0.4.25",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "code-context-engine",
-      "version": "0.4.24",
+      "version": "0.4.25",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Bumps version to 0.4.25.

Includes fixes from #115 and #116:
- Cap tree-sitter<0.26 to stop SIGSEGV/SIGBUS on cce init (ABI skew fix)
- Thread-local tree-sitter parsers to end concurrent-parse races