### PR TITLE
fix: Windows test failures (UTF-8 encoding, TOML escaping, symlink)

### DIFF
--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -41,7 +41,7 @@ def test_uninstall_removes_versioned_block(runner, tmp_path):
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
     user_content = "# My project\n\nSome user notes.\n\n"
-    (project_dir / "CLAUDE.md").write_text(user_content + _CCE_CLAUDE_MD_BLOCK)
+    (project_dir / "CLAUDE.md").write_text(user_content + _CCE_CLAUDE_MD_BLOCK, encoding="utf-8")
 
     result = _run_uninstall_in(runner, project_dir)
     assert result.exit_code == 0, result.output
@@ -76,7 +76,7 @@ def test_uninstall_deletes_claude_md_when_only_cce_block(runner, tmp_path):
     """If CLAUDE.md contained only the CCE block, the file is unlinked."""
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
-    (project_dir / "CLAUDE.md").write_text(_CCE_CLAUDE_MD_BLOCK)
+    (project_dir / "CLAUDE.md").write_text(_CCE_CLAUDE_MD_BLOCK, encoding="utf-8")
 
     result = _run_uninstall_in(runner, project_dir)
     assert result.exit_code == 0, result.output
@@ -215,7 +215,7 @@ def test_uninstall_full_cleanup(runner, tmp_path):
     (project_dir / ".mcp.json").write_text(json.dumps({
         "mcpServers": {"context-engine": {"command": "cce", "args": ["serve"]}}
     }))
-    (project_dir / "CLAUDE.md").write_text(_CCE_CLAUDE_MD_BLOCK)
+    (project_dir / "CLAUDE.md").write_text(_CCE_CLAUDE_MD_BLOCK, encoding="utf-8")
     (project_dir / ".context-engine.yaml").write_text("compression:\n  level: full\n")
     (project_dir / ".gitignore").write_text(".cce/\n.context-engine.yaml\n")
 

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -7,6 +7,8 @@ coexistence, legacy migration, and Windows-path TOML escaping.
 """
 from __future__ import annotations
 
+import json
+import sys
 import tomllib
 from unittest.mock import patch
 
@@ -73,6 +75,7 @@ def test_slug_differs_for_same_basename_in_different_paths(tmp_path):
     assert _project_slug(a) != _project_slug(b)
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="symlink requires Developer Mode or admin on Windows")
 def test_slug_resolves_symlinks(tmp_path):
     """Two paths pointing at the same on-disk directory (one via symlink)
     should produce the same slug — so re-running cce init via a symlinked
@@ -274,7 +277,7 @@ def test_legacy_section_is_migrated_to_per_project(fake_home, project_dir):
     user_config.write_text(
         '[mcp_servers.context-engine]\n'
         'command = "/old/cce"\n'
-        f'args = ["serve", "--project-dir", "{project_dir}"]\n'
+        f'args = {json.dumps(["serve", "--project-dir", str(project_dir)])}\n'
     )
     with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
         configure_mcp(project_dir, "codex")
@@ -392,7 +395,8 @@ def test_configure_preserves_user_header_comment(fake_home, project_dir):
         "\n"
         '[mcp_servers.linear]\n'
         'command = "linear-mcp"\n'
-        'args = []\n'
+        'args = []\n',
+        encoding="utf-8"
     )
     with patch("context_engine.editors.resolve_cce_binary", return_value="/usr/bin/cce"):
         configure_mcp(project_dir, "codex")

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -8,6 +8,7 @@ coexistence, legacy migration, and Windows-path TOML escaping.
 from __future__ import annotations
 
 import json
+import sys
 import tomllib
 from unittest.mock import patch
 
@@ -83,11 +84,13 @@ def test_slug_resolves_symlinks(tmp_path):
     link = tmp_path / "link"
     try:
         link.symlink_to(real)
-    except OSError:
-        pytest.fail(
-            "symlink_to failed — enable Windows Developer Mode or run as admin "
-            "to test symlink resolution"
-        )
+    except OSError as e:
+        if sys.platform == "win32" and getattr(e, "winerror", None) == 1314:
+            pytest.fail(
+                "symlink_to failed — enable Windows Developer Mode or run as admin "
+                "to test symlink resolution"
+            )
+        raise
     assert _project_slug(real) == _project_slug(link)
 
 

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -8,7 +8,6 @@ coexistence, legacy migration, and Windows-path TOML escaping.
 from __future__ import annotations
 
 import json
-import sys
 import tomllib
 from unittest.mock import patch
 
@@ -75,7 +74,6 @@ def test_slug_differs_for_same_basename_in_different_paths(tmp_path):
     assert _project_slug(a) != _project_slug(b)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="symlink requires Developer Mode or admin on Windows")
 def test_slug_resolves_symlinks(tmp_path):
     """Two paths pointing at the same on-disk directory (one via symlink)
     should produce the same slug — so re-running cce init via a symlinked
@@ -83,7 +81,13 @@ def test_slug_resolves_symlinks(tmp_path):
     real = tmp_path / "real"
     real.mkdir()
     link = tmp_path / "link"
-    link.symlink_to(real)
+    try:
+        link.symlink_to(real)
+    except OSError:
+        pytest.fail(
+            "symlink_to failed — enable Windows Developer Mode or run as admin "
+            "to test symlink resolution"
+        )
     assert _project_slug(real) == _project_slug(link)
 
 

--- a/tests/test_editors_codex.py
+++ b/tests/test_editors_codex.py
@@ -427,7 +427,7 @@ def test_configure_rewrites_section_when_command_drifts(fake_home, project_dir):
     user_config.write_text(
         f"[mcp_servers.cce-{slug}]\n"
         'command = "/old/path/to/cce"\n'
-        f'args = ["serve", "--project-dir", "{project_dir}"]\n'
+        f'args = {json.dumps(["serve", "--project-dir", str(project_dir)])}\n'
     )
     with patch("context_engine.editors.resolve_cce_binary", return_value="/new/path/to/cce"):
         changed = configure_mcp(project_dir, "codex")


### PR DESCRIPTION
Fix 6 pre-existing Windows test failures across 3 categories:

1. **Symlink privilege** — `test_slug_resolves_symlinks` needs Developer Mode/admin on Windows. Changed from `@pytest.mark.skipif` to try/except with `pytest.fail` and an actionable message guiding the user to enable Developer Mode or run as admin. Runs on CI and local dev machines with capability; fails informatively without it.

2. **UTF-8 vs cp1252 encoding** — 4 tests wrote non-ASCII content (em dashes in `_CCE_CLAUDE_MD_BLOCK`, header comment) with default system encoding instead of UTF-8. Added `encoding="utf-8"` to all affected `write_text()` calls.

3. **TOML invalid escape in Windows path** — `test_legacy_section_is_migrated_to_per_project` wrote raw f-string paths with backslashes (e.g. `C:\Users\...`), producing invalid TOML escape sequences. Fixed via `json.dumps()` for proper backslash escaping.

All 41 tests pass, 0 skipped (test runs on Windows when Developer Mode is enabled).