### PR TITLE
feat(indexer): add C# language support to AST chunker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "tree-sitter-go>=0.23",
     "tree-sitter-rust>=0.23",
     "tree-sitter-java>=0.23",
+    "tree-sitter-c-sharp>=0.23",
     "watchdog>=4.0",
     "mcp>=1.0",
     "httpx>=0.27",

--- a/src/context_engine/indexer/chunker.py
+++ b/src/context_engine/indexer/chunker.py
@@ -9,25 +9,30 @@ import tree_sitter_php as tsphp
 import tree_sitter_go as tsgo
 import tree_sitter_rust as tsrust
 import tree_sitter_java as tsjava
+import tree_sitter_c_sharp as tscsharp
 from tree_sitter import Language, Parser
 
 from context_engine.models import Chunk, ChunkType
 
 _FUNCTION_TYPES = {
     "function_definition", "function_declaration",  # Python, PHP, JS
-    "method_definition", "method_declaration",       # JS/TS, PHP/Go/Java
+    "method_definition", "method_declaration",       # JS/TS, PHP/Go/Java/C#
     "arrow_function",                                # JS/TS
     "function_item",                                 # Rust
+    "local_function_statement",                      # C#
 }
 _CLASS_TYPES = {
-    "class_definition", "class_declaration",  # Python, JS/TS, PHP, Java
-    "type_declaration",                        # Go (struct/interface)
-    "struct_item", "impl_item", "enum_item",   # Rust
+    "class_definition", "class_declaration",       # Python, JS/TS, PHP, Java, C#
+    "struct_declaration", "interface_declaration",  # C#
+    "record_declaration", "enum_declaration",       # Java, C#
+    "type_declaration",                             # Go (struct/interface)
+    "struct_item", "impl_item", "enum_item",        # Rust
 }
 _IMPORT_TYPES = {
     "import_statement", "import_from_statement",  # Python
     "import_declaration",                          # TypeScript, Go, Java
     "use_declaration",                             # PHP, Rust
+    "using_directive",                             # C#
 }
 
 _LANGUAGES = {
@@ -39,6 +44,7 @@ _LANGUAGES = {
     "go": Language(tsgo.language()),
     "rust": Language(tsrust.language()),
     "java": Language(tsjava.language()),
+    "csharp": Language(tscsharp.language()),
 }
 
 
@@ -144,6 +150,13 @@ class Chunker:
                     name = name.lstrip(".")
                     if name:
                         return name.split(".")[0]
+        elif node.type == "using_directive":
+            # C#: "using System.Collections.Generic;" — take the root namespace
+            # segment, mirroring the Python dotted-name convention below.
+            for child in node.children:
+                if child.type in ("qualified_name", "identifier"):
+                    name = source[child.start_byte:child.end_byte].strip()
+                    return name.split(".")[0]
         elif node.type == "import_declaration":
             # TypeScript (tree-sitter-typescript): "import React from 'react'"
             for child in node.children:

--- a/tests/indexer/test_chunker.py
+++ b/tests/indexer/test_chunker.py
@@ -34,6 +34,44 @@ class Animal {
 }
 '''
 
+CSHARP_CODE = '''
+using System;
+using System.Collections.Generic;
+
+namespace Shop.Payments
+{
+    public interface IPaymentGateway
+    {
+        Receipt Charge(decimal amount);
+    }
+
+    public record Receipt(string Id, decimal Amount);
+
+    public enum PaymentStatus
+    {
+        Pending,
+        Completed
+    }
+
+    public struct Money
+    {
+        public decimal Amount;
+    }
+
+    public class StripeGateway : IPaymentGateway
+    {
+        public Receipt Charge(decimal amount)
+        {
+            decimal ApplyFee(decimal baseAmount)
+            {
+                return baseAmount * 1.029m;
+            }
+            return new Receipt(Guid.NewGuid().ToString(), ApplyFee(amount));
+        }
+    }
+}
+'''
+
 def test_chunk_python_functions(chunker):
     chunks = chunker.chunk(PYTHON_CODE, file_path="calc.py", language="python")
     function_chunks = [c for c in chunks if c.chunk_type == ChunkType.FUNCTION]
@@ -60,6 +98,24 @@ def test_chunk_javascript(chunker):
     function_chunks = [c for c in chunks if c.chunk_type == ChunkType.FUNCTION]
     assert len(function_chunks) >= 1
 
+def test_chunk_csharp_functions(chunker):
+    chunks = chunker.chunk(CSHARP_CODE, file_path="Payments.cs", language="csharp")
+    function_chunks = [c for c in chunks if c.chunk_type == ChunkType.FUNCTION]
+    # Charge method, interface method signature, and ApplyFee local function
+    assert len(function_chunks) >= 3
+
+def test_chunk_csharp_types(chunker):
+    chunks = chunker.chunk(CSHARP_CODE, file_path="Payments.cs", language="csharp")
+    class_chunks = [c for c in chunks if c.chunk_type == ChunkType.CLASS]
+    # class, interface, record, enum, struct each become their own chunk
+    assert len(class_chunks) >= 5
+    contents = " ".join(c.content for c in class_chunks)
+    assert "interface IPaymentGateway" in contents
+    assert "record Receipt" in contents
+    assert "enum PaymentStatus" in contents
+    assert "struct Money" in contents
+    assert "class StripeGateway" in contents
+
 def test_chunk_unsupported_language_falls_back(chunker):
     chunks = chunker.chunk("some content here", file_path="data.txt", language="plaintext")
     assert len(chunks) == 1
@@ -81,6 +137,14 @@ def test_extract_imports_javascript():
     chunks, imports = chunker.chunk_with_imports(source, file_path="App.js", language="javascript")
     assert len(chunks) > 0
     assert "react" in imports
+
+
+def test_extract_imports_csharp():
+    chunker = Chunker()
+    chunks, imports = chunker.chunk_with_imports(CSHARP_CODE, file_path="Payments.cs", language="csharp")
+    assert len(chunks) > 0
+    # Both using directives resolve to their root namespace and deduplicate
+    assert imports == ["System"]
 
 
 def test_chunk_still_works_without_imports():

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "code-context-engine"
-version = "0.4.24"
+version = "0.4.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -371,6 +371,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sqlite-vec" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -423,6 +424,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
     { name = "tree-sitter", specifier = ">=0.22,<0.26" },
+    { name = "tree-sitter-c-sharp", specifier = ">=0.23" },
     { name = "tree-sitter-go", specifier = ">=0.23" },
     { name = "tree-sitter-java", specifier = ">=0.23" },
     { name = "tree-sitter-javascript", specifier = ">=0.21" },
@@ -2262,6 +2264,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/fb/7e2962bc1901daf264e7ce263b168e0139304a5f8f66c9b2baf20e550f87/tree_sitter_c_sharp-0.23.5.tar.gz", hash = "sha256:2635c7d5ec93e59f2e831b571bed99c4cc68a5d183a0994020aa769e1b990a71", size = 1147914, upload-time = "2026-04-14T16:11:22.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/c4/86d8d469400a856757a464a6ac01af97d8cdacbb595e62bdb98bf1e9db90/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:61e1981cf21b09ee547b9c4c68e64fb4394325f8fc8d5f6d50d41471eba923ea", size = 333658, upload-time = "2026-04-14T16:11:11.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/13/593c8603f834eaf15082b81e079289fc9f062b4c0ab5b9489134084eec06/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a75994a11f6fed3f5b8c36ad6a00e5dc43205bd912c43af3a2a54fdf649664eb", size = 376296, upload-time = "2026-04-14T16:11:12.972Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5a/a8855cbb5bbab28adb29c2c7f0e7be5a9f1d21450c13b3c3e613190d9b8c/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aa88a780204cd153c4c1ae2d59c654cee1402212fa0d069823d6d34301587438", size = 358333, upload-time = "2026-04-14T16:11:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/e0f391e343f5424d0627e3b6886c77baeb1249a3f10986be00b0b64ecdab/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea38fb095d85d360dc5a0bec2fa605e496228876f798c9e089d5f0e72bcef46", size = 359448, upload-time = "2026-04-14T16:11:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fc/10f807ac79f928241c5e0d827fdaf91e97dfba662fc7e07d7bd664140ec1/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:05a9256415e7f24d4f133133794a9c224c60d19f677a04e2f6a94c25090b6d65", size = 358144, upload-time = "2026-04-14T16:11:17.087Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2a/6c3e12ef0cf09138717fcc02e1de8b76a3928d1bed65c7e3c2bd3172bcef/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8636dc70b5a373c35c1036ed5de98e801f2e4d105ae41e2e20b6804c36e3bf33", size = 357525, upload-time = "2026-04-14T16:11:18.214Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/bd287b092d611df95a9149117fd27b5947ce75527113d6898a4b4e2c8858/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_amd64.whl", hash = "sha256:41a28cfa3d9ea50f5629e44550a03188c8fbd5079803dfc03554b6fd594b33fa", size = 338756, upload-time = "2026-04-14T16:11:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fb/114ff43fdd256d0befed32f77c1dadee9517867181c70794571f718ed05c/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_arm64.whl", hash = "sha256:2de4ebf95ddc2e92cd3105c8a8e0e7ec646bc82f52bfaf2f3acec0fa2401ec09", size = 337260, upload-time = "2026-04-14T16:11:20.849Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Register tree-sitter-c-sharp so .cs files get semantic chunks instead of the whole-file fallback:

- chunk methods and local functions as FUNCTION chunks
- chunk classes, interfaces, structs, records and enums as CLASS chunks
- extract root namespaces from using directives for IMPORTS edges

record_declaration and enum_declaration also improve Java chunking, which shares those node types.