### PR TITLE
fix: use correct storage path in run_benchmark.py

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -126,7 +126,7 @@ async def run_benchmark(
     print(f"  Cache: {idx_result.cache_hits} hits, {idx_result.cache_misses} misses")
 
     # Set up retriever + compressor
-    storage_base = Path(config.storage_path) / project_dir.name
+    storage_base = project_storage_dir(config, project_dir)
     backend = LocalBackend(base_path=str(storage_base))
     embedder = Embedder(model_name=config.embedding_model)
     retriever = HybridRetriever(backend=backend, embedder=embedder)


### PR DESCRIPTION
## Summary
`benchmarks/run_benchmark.py` was missed in #106. It still uses `Path(config.storage_path) / project_dir.name` instead of `project_storage_dir()`, so it looks in a different directory than where the index is written (`<name>-<hash>`). Because of that, every benchmark query returns 0 results.

* Found this while producing new results for #27 and #28 every query
came back as a MISS with 0 tokens until I traced it to this mismatch.

## Fix
Use the same `project_storage_dir()` helper the indexer already uses.

## Test plan
- [x] Ran `python benchmarks/run_benchmark.py --repo https://github.com/expressjs/express.git --source-dir lib` before the fix: all 20 queries MISS, 0% everywhere
- [x] Same command after the fix: 20/20 HIT, 93.6% retrieval savings, 97.1% combined
- [ ] Note for maintainers: `benchmarks/results/fastapi.md`, `fiber.md`, `chi.md` were generated before #106 landed and are stale relative to current `main`, though still historically valid. Happy to rerun them if useful.
