### PR TITLE
fix(indexer): UTF-8 encoding for git log on non-UTF-8 Windows locales

### DIFF
--- a/src/context_engine/indexer/git_indexer.py
+++ b/src/context_engine/indexer/git_indexer.py
@@ -31,7 +31,8 @@ async def index_commits(
 
     meta_result = await asyncio.to_thread(
         subprocess.run,
-        ["git", "log", range_arg, "--format=%H%n%an%n%ai%n%s%n%b%x00"],
+        ["git", "-c", "i18n.logOutputEncoding=UTF-8",
+         "log", range_arg, "--format=%H%n%an%n%ai%n%s%n%b%x00"],
         cwd=project_dir, capture_output=True, text=True,
         encoding="utf-8", errors="replace", check=False,
     )
@@ -42,7 +43,8 @@ async def index_commits(
 
     files_result = await asyncio.to_thread(
         subprocess.run,
-        ["git", "log", range_arg, "--name-only", "--format=%H"],
+        ["git", "-c", "i18n.logOutputEncoding=UTF-8",
+         "log", range_arg, "--name-only", "--format=%H"],
         cwd=project_dir, capture_output=True, text=True,
         encoding="utf-8", errors="replace", check=False,
     )

--- a/src/context_engine/indexer/git_indexer.py
+++ b/src/context_engine/indexer/git_indexer.py
@@ -32,7 +32,8 @@ async def index_commits(
     meta_result = await asyncio.to_thread(
         subprocess.run,
         ["git", "log", range_arg, "--format=%H%n%an%n%ai%n%s%n%b%x00"],
-        cwd=project_dir, capture_output=True, text=True, check=False,
+        cwd=project_dir, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", check=False,
     )
 
     if meta_result.returncode != 0:
@@ -42,7 +43,8 @@ async def index_commits(
     files_result = await asyncio.to_thread(
         subprocess.run,
         ["git", "log", range_arg, "--name-only", "--format=%H"],
-        cwd=project_dir, capture_output=True, text=True, check=False,
+        cwd=project_dir, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", check=False,
     )
 
     changed_files_by_hash: dict[str, list[str]] = {}

--- a/tests/indexer/test_git_indexer.py
+++ b/tests/indexer/test_git_indexer.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from context_engine.indexer.git_indexer import index_commits
@@ -111,7 +112,23 @@ async def test_non_ascii_commit_metadata(tmp_path):
         cwd=tmp_path, capture_output=True, check=True,
     )
 
-    chunks, nodes, edges = await index_commits(tmp_path, max_commits=10)
+    calls: list[dict] = []
+    real_run = subprocess.run
+
+    def spy_run(*args, **kwargs):
+        calls.append(kwargs)
+        return real_run(*args, **kwargs)
+
+    with patch("subprocess.run", side_effect=spy_run):
+        chunks, _, _ = await index_commits(tmp_path, max_commits=10)
+
     assert len(chunks) == 1
     assert "田中太郎" in chunks[0].metadata["author"]
     assert "機能追加" in chunks[0].content
+
+    # index_commits must pass encoding/errors so non-ASCII never crashes
+    git_log_calls = [c for c in calls if c.get("encoding") is not None]
+    assert git_log_calls, "index_commits should pass encoding kwarg to subprocess.run"
+    for c in git_log_calls:
+        assert c["encoding"] == "utf-8"
+        assert c["errors"] == "replace"

--- a/tests/indexer/test_git_indexer.py
+++ b/tests/indexer/test_git_indexer.py
@@ -89,3 +89,29 @@ async def test_incremental_since_sha(git_repo):
     first_sha = chunks_all[-1].metadata["hash"]  # oldest commit
     chunks_new, _, _ = await index_commits(git_repo, since_sha=first_sha)
     assert len(chunks_new) < len(chunks_all)
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_commit_metadata(tmp_path):
+    """Non-ASCII author names and commit messages must not crash indexing,
+    even when the system locale prefers a non-UTF-8 encoding (#140)."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "田中太郎"],
+        cwd=tmp_path, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "tanaka@example.com"],
+        cwd=tmp_path, capture_output=True, check=True,
+    )
+    (tmp_path / "hello.py").write_text("print('こんにちは')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-m", "機能追加: 挨拶モジュール"],
+        cwd=tmp_path, capture_output=True, check=True,
+    )
+
+    chunks, nodes, edges = await index_commits(tmp_path, max_commits=10)
+    assert len(chunks) == 1
+    assert "田中太郎" in chunks[0].metadata["author"]
+    assert "機能追加" in chunks[0].content


### PR DESCRIPTION
## Summary

Fixes #140. Git history indexing fails with `UnicodeDecodeError` on Windows machines using non-UTF-8 system locales (e.g. Korean cp949, Japanese Shift_JIS, Chinese GBK).

The two `subprocess.run` calls in `index_commits` used `text=True` without an explicit `encoding=`. Python decodes subprocess output using `locale.getpreferredencoding(False)`, which on Windows returns the system ANSI codepage. Since git log output is always UTF-8, any non-ASCII commit message or author name that isn't valid in the system codepage raises `UnicodeDecodeError`.

Fix: pass `encoding="utf-8", errors="replace"` on both calls, matching git's actual output encoding. The `errors="replace"` fallback handles the rare case where git output contains non-UTF-8 bytes (e.g. legacy repos with Latin-1 commit messages) by substituting `U+FFFD` instead of crashing.

One-line change per call site, no new dependencies.