### PR TITLE
feat(memory): ambient nudges for record_decision and record_code_area

### DIFF
--- a/src/context_engine/integration/mcp_server.py
+++ b/src/context_engine/integration/mcp_server.py
@@ -469,6 +469,12 @@ class ContextEngineMCP:
         # Lazy indexing flag — triggers on first context_search if index is empty.
         self._lazy_indexed = False
 
+        # Memory nudge state — tracks tool activity so context_search can
+        # append reminders when the agent hasn't been recording (#nudges).
+        # Reset on every record_decision / record_code_area call.
+        self._searches_since_last_decision = 0
+        self._has_recorded_decision = False
+
         self._register_tools()
         self._register_prompts()
 
@@ -708,6 +714,76 @@ class ContextEngineMCP:
                 meta={"level": self._output_level},
             )
         return out
+
+    # ── memory nudges ───────────────────────────────────────────────────
+
+    # Thresholds for triggering nudges. After the first record_decision,
+    # the search threshold doubles — the agent has shown it knows how, so
+    # we nudge less aggressively.
+    _DECISION_NUDGE_FIRST = 4
+    _DECISION_NUDGE_REPEAT = 8
+    _CODE_AREA_NUDGE_THRESHOLD = 3
+    _CODE_AREA_NUDGE_MAX_FILES = 5
+
+    def _build_nudge(self) -> str:
+        """Return a nudge string to append to context_search results, or "".
+
+        Two independent triggers:
+        1. Decision nudge: N searches with 0 decisions recorded.
+        2. Code area nudge: M files touched (via search/expand) but not
+           explicitly record_code_area'd this session.
+
+        Both can fire in the same response. The "skip if" clause gives the
+        agent permission to ignore the nudge when it's just reading.
+        """
+        parts: list[str] = []
+
+        # ── decision nudge ────────────────────────────────────────────
+        threshold = (
+            self._DECISION_NUDGE_REPEAT
+            if self._has_recorded_decision
+            else self._DECISION_NUDGE_FIRST
+        )
+        if self._searches_since_last_decision >= threshold:
+            n = self._searches_since_last_decision
+            snap = self._session_capture.get_session_snapshot(self._session_id)
+            n_decisions = len(snap["decisions"]) if snap else 0
+            parts.append(
+                f"[CCE] {n} context searches this session, "
+                f"{n_decisions} decision(s) recorded.\n"
+                f"If you chose a library, resolved an ambiguity, or "
+                f"established a convention, call "
+                f'record_decision(decision="...", reason="...").\n'
+                f"Skip if this session is just exploration/reading."
+            )
+
+        # ── code area nudge ───────────────────────────────────────────
+        snap = self._session_capture.get_session_snapshot(self._session_id)
+        if snap:
+            touched = set(snap.get("touched_files", {}).keys())
+            recorded = {
+                ca["file_path"] for ca in snap.get("code_areas", [])
+            }
+            unrecorded = sorted(touched - recorded)
+            if len(unrecorded) >= self._CODE_AREA_NUDGE_THRESHOLD:
+                shown = unrecorded[:self._CODE_AREA_NUDGE_MAX_FILES]
+                suffix = (
+                    f" (+{len(unrecorded) - len(shown)} more)"
+                    if len(unrecorded) > len(shown) else ""
+                )
+                file_list = ", ".join(shown) + suffix
+                parts.append(
+                    f"[CCE] {len(unrecorded)} files explored but not "
+                    f"recorded: {file_list}\n"
+                    f"If you modified or traced a non-obvious flow, call "
+                    f'record_code_area(file_path="...", '
+                    f'description="...").\n'
+                    f"Skip for files you only glanced at."
+                )
+
+        if not parts:
+            return ""
+        return "\n\n---\n" + "\n\n".join(parts)
 
     def get_tool_names(self) -> list[str]:
         return list(self.TOOL_NAMES)
@@ -1048,6 +1124,14 @@ class ContextEngineMCP:
         self._persist_current_session()
 
         body = _format_results_with_overflow(inline_chunks, overflow_chunks)
+        # Memory nudge — appended before output compression so the agent
+        # sees it as part of the tool result. Fires only when thresholds
+        # are met (see _build_nudge). Increment BEFORE building the nudge
+        # so the current search counts toward the threshold.
+        self._searches_since_last_decision += 1
+        nudge = self._build_nudge()
+        if nudge:
+            body = body + nudge
         body = self._apply_output_compression(body)
         # Only note omissions the retriever actually made (threshold or
         # marginal stop) — chunk-count heuristics false-positive on every
@@ -1246,6 +1330,10 @@ class ContextEngineMCP:
         reason = memory_db.scrub_pii(reason)
         self._session_capture.record_decision(self._session_id, decision, reason)
         self._persist_current_session()
+        # Reset nudge state — the agent recorded something, give it a
+        # longer leash before the next nudge.
+        self._searches_since_last_decision = 0
+        self._has_recorded_decision = True
         # Dual-write into memory.db. `decision` and `reason` are compressed
         # via the grammar module before INSERT — structured tokens (paths,
         # versions, identifiers) are preserved byte-for-byte; only prose

--- a/src/context_engine/integration/mcp_server.py
+++ b/src/context_engine/integration/mcp_server.py
@@ -737,6 +737,7 @@ class ContextEngineMCP:
         agent permission to ignore the nudge when it's just reading.
         """
         parts: list[str] = []
+        snap = self._session_capture.get_session_snapshot(self._session_id)
 
         # ── decision nudge ────────────────────────────────────────────
         threshold = (
@@ -746,8 +747,7 @@ class ContextEngineMCP:
         )
         if self._searches_since_last_decision >= threshold:
             n = self._searches_since_last_decision
-            snap = self._session_capture.get_session_snapshot(self._session_id)
-            n_decisions = len(snap["decisions"]) if snap else 0
+            n_decisions = len(snap.get("decisions", [])) if snap else 0
             parts.append(
                 f"[CCE] {n} context searches this session, "
                 f"{n_decisions} decision(s) recorded.\n"
@@ -758,7 +758,6 @@ class ContextEngineMCP:
             )
 
         # ── code area nudge ───────────────────────────────────────────
-        snap = self._session_capture.get_session_snapshot(self._session_id)
         if snap:
             touched = set(snap.get("touched_files", {}).keys())
             recorded = {

--- a/src/context_engine/integration/mcp_server.py
+++ b/src/context_engine/integration/mcp_server.py
@@ -471,7 +471,7 @@ class ContextEngineMCP:
 
         # Memory nudge state — tracks tool activity so context_search can
         # append reminders when the agent hasn't been recording (#nudges).
-        # Reset on every record_decision / record_code_area call.
+        # Reset on every record_decision call.
         self._searches_since_last_decision = 0
         self._has_recorded_decision = False
 

--- a/src/context_engine/memory/hook_installer.py
+++ b/src/context_engine/memory/hook_installer.py
@@ -97,7 +97,7 @@ if command -v bash >/dev/null 2>&1; then
     bash -c "exec 3<>/dev/tcp/127.0.0.1/${PORT}" 2>/dev/null || exit 0
 fi
 
-if [ "${HOOK_NAME}" = "SessionStart" ]; then
+if [ "${HOOK_NAME}" = "SessionStart" ] || [ "${HOOK_NAME}" = "Stop" ]; then
     RESPONSE="$(curl -sf -m 2 -X POST -H "Content-Type: application/json" \\
         --data-binary @- "http://127.0.0.1:${PORT}/hooks/${HOOK_NAME}" \\
         2>/dev/null || true)"
@@ -154,17 +154,19 @@ REM See the POSIX comment above for the motivation (#67).
 powershell -NoProfile -Command "$ErrorActionPreference='Stop'; try { (New-Object Net.Sockets.TcpClient).Connect('127.0.0.1',%PORT%); exit 0 } catch { exit 1 }" >nul 2>&1
 if errorlevel 1 exit /b 0
 
-if /i "%HOOK_NAME%"=="SessionStart" (
-    set "TMP_RESP=%TEMP%\\cce_hook_resp_%RANDOM%.txt"
-    curl -sf -m 2 -X POST -H "Content-Type: application/json" ^
-        --data-binary @- "http://127.0.0.1:%PORT%/hooks/%HOOK_NAME%" ^
-        > "%TMP_RESP%" 2>nul
-    if exist "%TMP_RESP%" type "%TMP_RESP%"
-    if exist "%TMP_RESP%" del "%TMP_RESP%" >nul 2>&1
-) else (
-    curl -sf -m 1 -X POST -H "Content-Type: application/json" ^
-        --data-binary @- "http://127.0.0.1:%PORT%/hooks/%HOOK_NAME%" >nul 2>&1
-)
+if /i "%HOOK_NAME%"=="SessionStart" goto :capture_response
+if /i "%HOOK_NAME%"=="Stop" goto :capture_response
+curl -sf -m 1 -X POST -H "Content-Type: application/json" ^
+    --data-binary @- "http://127.0.0.1:%PORT%/hooks/%HOOK_NAME%" >nul 2>&1
+goto :eof
+
+:capture_response
+set "TMP_RESP=%TEMP%\\cce_hook_resp_%RANDOM%.txt"
+curl -sf -m 2 -X POST -H "Content-Type: application/json" ^
+    --data-binary @- "http://127.0.0.1:%PORT%/hooks/%HOOK_NAME%" ^
+    > "%TMP_RESP%" 2>nul
+if exist "%TMP_RESP%" type "%TMP_RESP%"
+if exist "%TMP_RESP%" del "%TMP_RESP%" >nul 2>&1
 exit /b 0
 """
 

--- a/src/context_engine/memory/hooks.py
+++ b/src/context_engine/memory/hooks.py
@@ -391,7 +391,9 @@ async def handle_stop(request: web.Request) -> web.Response:
     nudge = _build_stop_nudge(conn, session_id)
     if nudge:
         return web.Response(text=nudge, content_type="text/plain")
-    return web.json_response({"ok": True})
+    # No nudge — return empty body so the hook script has nothing to
+    # inject into the model context (JSON like {"ok":true} would pollute it).
+    return web.Response(status=204)
 
 
 def _build_stop_nudge(conn: sqlite3.Connection, session_id: str) -> str:

--- a/src/context_engine/memory/hooks.py
+++ b/src/context_engine/memory/hooks.py
@@ -382,7 +382,7 @@ async def handle_stop(request: web.Request) -> web.Response:
         conn.commit()
     except Exception:
         log.exception("Stop enqueue failed")
-        return web.json_response({"ok": False}, status=202)
+        return web.Response(status=202)
 
     # Memory nudge — summarise unrecorded activity so the agent can fire
     # off quick record_decision / record_code_area calls before the session
@@ -399,9 +399,10 @@ async def handle_stop(request: web.Request) -> web.Response:
 def _build_stop_nudge(conn: sqlite3.Connection, session_id: str) -> str:
     """Build a session-end nudge summarising unrecorded activity.
 
-    Queries memory.db for tool_events (context_search calls) and decisions
-    recorded during this session. Returns a short directive if activity
-    was significant but recording was low. Returns "" if nothing to nudge.
+    Queries memory.db for tool_events (context_search calls), decisions,
+    and code_areas recorded during this session. Returns a short directive
+    if activity was significant but recording was low. Returns "" if
+    nothing to nudge.
     """
     try:
         # Count context_search tool calls this session

--- a/src/context_engine/memory/hooks.py
+++ b/src/context_engine/memory/hooks.py
@@ -383,7 +383,73 @@ async def handle_stop(request: web.Request) -> web.Response:
     except Exception:
         log.exception("Stop enqueue failed")
         return web.json_response({"ok": False}, status=202)
+
+    # Memory nudge — summarise unrecorded activity so the agent can fire
+    # off quick record_decision / record_code_area calls before the session
+    # ends. The hook script captures Stop stdout (like SessionStart) and
+    # injects it into the model context.
+    nudge = _build_stop_nudge(conn, session_id)
+    if nudge:
+        return web.Response(text=nudge, content_type="text/plain")
     return web.json_response({"ok": True})
+
+
+def _build_stop_nudge(conn: sqlite3.Connection, session_id: str) -> str:
+    """Build a session-end nudge summarising unrecorded activity.
+
+    Queries memory.db for tool_events (context_search calls) and decisions
+    recorded during this session. Returns a short directive if activity
+    was significant but recording was low. Returns "" if nothing to nudge.
+    """
+    try:
+        # Count context_search tool calls this session
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM tool_events "
+            "WHERE session_id = ? AND tool_name = 'context_search'",
+            (session_id,),
+        ).fetchone()
+        n_searches = int(row["n"]) if row else 0
+
+        # Count decisions recorded this session
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM decisions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        n_decisions = int(row["n"]) if row else 0
+
+        # Count code_areas recorded this session
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM code_areas WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        n_code_areas = int(row["n"]) if row else 0
+
+        # Only nudge if there was real activity (4+ searches) and
+        # recording was sparse.
+        if n_searches < 4:
+            return ""
+        parts: list[str] = []
+        if n_decisions == 0:
+            parts.append(
+                "If you chose a library, resolved an ambiguity, or "
+                "established a convention, call "
+                'record_decision(decision="...", reason="...") now.'
+            )
+        if n_code_areas == 0:
+            parts.append(
+                "If you modified or traced non-obvious code, call "
+                'record_code_area(file_path="...", description="...") now.'
+            )
+        if not parts:
+            return ""
+        header = (
+            f"[CCE session end] {n_searches} searches, "
+            f"{n_decisions} decision(s), {n_code_areas} code area(s) recorded."
+        )
+        return header + "\n" + "\n".join(parts)
+    except Exception:
+        log.debug("Stop nudge query failed", exc_info=True)
+        return ""
 
 
 async def handle_session_end(request: web.Request) -> web.Response:

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -30,6 +30,9 @@ def _make_server(tmp_path):
     # _record_bucket already guards on this; tests don't need a real db.
     server._memory_conn = None
     server._storage_base = tmp_path
+    # Memory nudge state (see ContextEngineMCP.__init__)
+    server._searches_since_last_decision = 0
+    server._has_recorded_decision = False
     return server
 
 
@@ -176,6 +179,9 @@ def _make_search_server(tmp_path, dropped_low_value):
     server._compressor.compress = AsyncMock(return_value=[stub_chunk])
     server._session_capture = MagicMock()
     server._session_capture.touch_files = MagicMock()
+    server._session_capture.get_session_snapshot = MagicMock(return_value={
+        "decisions": [], "code_areas": [], "touched_files": {},
+    })
     server._persist_current_session = MagicMock()
     server._record = MagicMock()
     server._append_audit_log = MagicMock()
@@ -208,3 +214,62 @@ async def test_context_search_no_note_when_nothing_dropped(tmp_path):
     result = await server._handle_context_search({"query": "find something", "top_k": 5})
     text = result[0].text
     assert "lower-confidence results omitted" not in text
+
+
+@pytest.mark.asyncio
+async def test_decision_nudge_fires_after_threshold(tmp_path):
+    """After 4 context_search calls with no record_decision, the nudge appears."""
+    server = _make_search_server(tmp_path, dropped_low_value=0)
+    # First 3 searches: no nudge
+    for _ in range(3):
+        result = await server._handle_context_search({"query": "q", "top_k": 5})
+        assert "[CCE]" not in result[0].text
+    # 4th search: nudge fires
+    result = await server._handle_context_search({"query": "q", "top_k": 5})
+    assert "[CCE] 4 context searches" in result[0].text
+    assert "record_decision" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_decision_nudge_resets_after_record(tmp_path):
+    """Recording a decision resets the search counter."""
+    server = _make_search_server(tmp_path, dropped_low_value=0)
+    # Trigger nudge
+    for _ in range(4):
+        await server._handle_context_search({"query": "q", "top_k": 5})
+    # Simulate record_decision resetting state
+    server._searches_since_last_decision = 0
+    server._has_recorded_decision = True
+    # Next search: no nudge (counter reset, higher threshold now)
+    result = await server._handle_context_search({"query": "q", "top_k": 5})
+    assert "[CCE]" not in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_code_area_nudge_fires_with_unrecorded_files(tmp_path):
+    """Nudge appears when 3+ files are touched but none recorded as code areas."""
+    server = _make_search_server(tmp_path, dropped_low_value=0)
+    # Simulate 3 touched files with no code_areas recorded
+    server._session_capture.get_session_snapshot = MagicMock(return_value={
+        "decisions": [], "code_areas": [],
+        "touched_files": {"a.py": 1, "b.py": 2, "c.py": 1},
+    })
+    result = await server._handle_context_search({"query": "q", "top_k": 5})
+    assert "files explored but not recorded" in result[0].text
+    assert "record_code_area" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_code_area_nudge_excludes_recorded_files(tmp_path):
+    """Files that were record_code_area'd don't count toward the threshold."""
+    server = _make_search_server(tmp_path, dropped_low_value=0)
+    server._session_capture.get_session_snapshot = MagicMock(return_value={
+        "decisions": [], "touched_files": {"a.py": 1, "b.py": 2, "c.py": 1},
+        "code_areas": [
+            {"file_path": "a.py", "description": "x", "timestamp": 0},
+            {"file_path": "b.py", "description": "y", "timestamp": 0},
+        ],
+    })
+    result = await server._handle_context_search({"query": "q", "top_k": 5})
+    # Only 1 unrecorded file (c.py) — below threshold
+    assert "[CCE]" not in result[0].text or "files explored" not in result[0].text

--- a/tests/memory/test_hooks.py
+++ b/tests/memory/test_hooks.py
@@ -268,7 +268,7 @@ async def test_stop_enqueues_turn_compression(hook_app, aiohttp_client):
         "/hooks/Stop",
         json={"session_id": "abc"},
     )
-    assert resp.status == 200
+    assert resp.status in (200, 204)
     pending = list(conn.execute(
         "SELECT kind, session_id, prompt_number FROM pending_compressions"
     ))
@@ -585,7 +585,7 @@ async def test_stop_without_session_start_does_not_crash(hook_app, aiohttp_clien
         "/hooks/Stop",
         json={"session_id": "orphan3"},
     )
-    assert resp.status == 200
+    assert resp.status in (200, 204)
 
 
 async def test_session_end_without_session_start_does_not_crash(hook_app, aiohttp_client):
@@ -597,3 +597,74 @@ async def test_session_end_without_session_start_does_not_crash(hook_app, aiohtt
         json={"session_id": "orphan4", "exit_reason": "normal"},
     )
     assert resp.status == 200
+
+
+# ── Stop nudge tests ────────────────────────────────────────────────────
+
+
+async def test_stop_nudge_fires_with_searches_no_decisions(hook_app, aiohttp_client):
+    """Stop returns a nudge when there were 4+ searches but no decisions."""
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "nudge1", "project": "demo"},
+    )
+    # Seed 5 context_search tool events.
+    for i in range(5):
+        conn.execute(
+            "INSERT INTO tool_events (session_id, tool_name, prompt_number, "
+            "created_at_epoch, created_at) VALUES (?, 'context_search', ?, ?, ?)",
+            ("nudge1", i + 1, 1700000000 + i, "2023-11-14T22:13:20"),
+        )
+    conn.commit()
+    resp = await client.post("/hooks/Stop", json={"session_id": "nudge1"})
+    assert resp.status == 200
+    text = await resp.text()
+    assert "5 searches" in text
+    assert "record_decision" in text
+
+
+async def test_stop_nudge_silent_when_few_searches(hook_app, aiohttp_client):
+    """Stop returns 204 (no nudge) when fewer than 4 searches."""
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "nudge2", "project": "demo"},
+    )
+    conn.execute(
+        "INSERT INTO tool_events (session_id, tool_name, prompt_number, "
+        "created_at_epoch, created_at) VALUES "
+        "('nudge2', 'context_search', 1, 1700000000, '2023-11-14T22:13:20')",
+    )
+    conn.commit()
+    resp = await client.post("/hooks/Stop", json={"session_id": "nudge2"})
+    assert resp.status == 204
+
+
+async def test_stop_nudge_silent_when_decisions_recorded(hook_app, aiohttp_client):
+    """Stop returns 204 when searches exist but decisions were recorded."""
+    app, conn = hook_app
+    client = await aiohttp_client(app)
+    await client.post(
+        "/hooks/SessionStart", json={"session_id": "nudge3", "project": "demo"},
+    )
+    for i in range(6):
+        conn.execute(
+            "INSERT INTO tool_events (session_id, tool_name, prompt_number, "
+            "created_at_epoch, created_at) VALUES (?, 'context_search', ?, ?, ?)",
+            ("nudge3", i + 1, 1700000000 + i, "2023-11-14T22:13:20"),
+        )
+    conn.execute(
+        "INSERT INTO decisions (session_id, decision, reason, source, "
+        "created_at_epoch, created_at) VALUES "
+        "('nudge3', 'Use Redis', 'Fast cache', 'manual', "
+        "1700001000, '2023-11-14T22:30:00')",
+    )
+    conn.execute(
+        "INSERT INTO code_areas (session_id, file_path, description, "
+        "created_at_epoch) VALUES "
+        "('nudge3', 'src/cache.py', 'Redis wrapper', 1700001000)",
+    )
+    conn.commit()
+    resp = await client.post("/hooks/Stop", json={"session_id": "nudge3"})
+    assert resp.status == 204


### PR DESCRIPTION
## Summary

CCE's cross-session memory depends on the agent calling `record_decision` and `record_code_area`, but that only happens when the agent obeys CLAUDE.md instructions. If context compacts or the agent just forgets, the session produces no durable memory. This PR makes recording ambient by nudging the agent from within tool results.

**Inline nudges on `context_search`:**

- **Decision nudge** fires after 4 context searches with 0 decisions recorded this session. Message includes the search count and a directive to call `record_decision` if a non-obvious choice was made. Includes "skip if this session is just exploration/reading" to prevent garbage recordings. After the first `record_decision`, the threshold doubles to 8 (longer leash once the agent has shown it knows how).

- **Code area nudge** fires when 3+ files have been explored (via `context_search` or `expand_chunk`) without any `record_code_area` call. Lists the specific unrecorded file paths (max 5) so the agent has concrete material to act on rather than a generic reminder. Files that were already `record_code_area`'d are excluded from the count.

Both nudges can fire in the same response. They appear before the output compression directive, as part of the tool result text.

**Stop hook summary:**

The existing Stop hook (fires on session end) now returns a compact summary: search count, decisions recorded, code areas recorded, with a directive to record if counts are low. The hook script is updated to capture Stop stdout (previously only SessionStart output was captured). Users get the updated script on next `cce init`.

Example nudge (after 4th search, 0 decisions):
```
[CCE] 4 context searches this session, 0 decision(s) recorded.
If you chose a library, resolved an ambiguity, or established a convention, call record_decision(decision="...", reason="...").
Skip if this session is just exploration/reading.
```

Example code area nudge:
```
[CCE] 3 files explored but not recorded: src/auth.py, src/middleware.py, src/routes.py
If you modified or traced a non-obvious flow, call record_code_area(file_path="...", description="...").
Skip for files you only glanced at.
```