### PR TITLE
fix: constrain mcp to <2 so the MCP server still starts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ dependencies = [
     "tree-sitter-java>=0.23",
     "tree-sitter-c-sharp>=0.23",
     "watchdog>=4.0",
-    "mcp>=1.0",
+    # Upper bound is deliberate. mcp 2.0.0 removed the decorator registration API
+    # (Server.list_tools / Server.call_tool), so an unbounded "mcp>=1.0" resolves to 2.x
+    # and ContextEngineMCP raises AttributeError in __init__ — the MCP server does not
+    # start at all. See #147. Lift this once the server is ported to the 2.x API.
+    "mcp>=1.0,<2",
     "httpx>=0.27",
     "fastapi>=0.110",
     "uvicorn>=0.29",


### PR DESCRIPTION
Fixes #147.

## What broke

`mcp 2.0.0` was published on 2026-07-28 and removed the decorator-based registration API. `pyproject.toml` required `mcp>=1.0` with no upper bound, so from that moment every fresh resolve installs 2.x and `ContextEngineMCP` raises during construction:

```
>       @self._server.list_tools()
E       AttributeError: 'Server' object has no attribute 'list_tools'
src/context_engine/integration/mcp_server.py:718: AttributeError
```

It fails in `__init__`, so this isn't a degraded feature — **the MCP server does not start**, which is the primary way the package is used with Claude Code, Cursor and the other listed agents.

`main` CI went red the same day with no source change; the dependency moved underneath it:

| run | date | commit | result |
|---|---|---|---|
| CI | 2026-07-28 | `675636d` | **failure** |
| CI | 2026-07-13 | `da47cac` | success |
| CI | 2026-07-13 | `562e609` | success |

## The change

One line, plus a comment saying why it is there and when to remove it:

```toml
"mcp>=1.0,<2",
```

## Why only a pin

Two call sites depend on the removed API — `mcp_server.py:718` (`list_tools`) and `:863` (`call_tool`). mcp 2.0's `Server` exposes `add_request_handler`, `middleware`, `extensions` and nothing matching `*tool*` at all, so this is a port rather than a rename.

That port is a design decision that belongs to you — move to `add_request_handler`, support both majors behind a shim, or require 2.x and raise the floor — so this PR only restores a working install and leaves the direction open. Happy to do the port as a follow-up if you tell me which way you want it.

## Verification

Windows / Python 3.13, clean venv, `pip install -e ".[dev,local]"`:

| | mcp resolved | `tests/test_real_life.py` |
|---|---|---|
| before | 2.0.0 | 2 failed, 17 passed |
| after | 1.29.0 | **19 passed** |

The failures were all `AttributeError` at the same line, in every test whose setup constructs `ContextEngineMCP`.
