### PR TITLE
fix(windows): _process_alive misreports process state

### DIFF
--- a/src/context_engine/services.py
+++ b/src/context_engine/services.py
@@ -13,6 +13,8 @@ import os
 import signal
 import socket
 import subprocess
+
+import psutil
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -56,13 +58,36 @@ def _remove_pid(name: str) -> None:
 
 
 def _process_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
+    """Is this PID a live process?
+
+    os.kill(pid, 0) is the POSIX idiom, but it does not carry to Windows, where
+    os.kill is implemented over OpenProcess/TerminateProcess rather than signals.
+    Measured on Windows 11 / CPython 3.13, the previous implementation had two
+    distinct faults:
+
+      * a PID that never existed raised OSError(WinError 87, "The parameter is
+        incorrect") instead of ProcessLookupError, so it escaped both excepts and
+        propagated out of a status check;
+      * a recently-exited PID did NOT raise at all, because a process handle stays
+        openable while any handle to it remains, so the function returned True and
+        a dead service was reported as running.
+
+    The second is the more damaging: it is silent, and it makes `services status`
+    claim a crashed service is healthy.
+
+    psutil is already a core dependency and gets this right on every platform, so
+    use it rather than hand-rolling the Windows path. Zombies are excluded
+    deliberately — on POSIX a reaped-but-not-collected child still "exists" but is
+    not running, which is the same lie in a different shape.
+    """
+    if pid <= 0:
         return False
-    except PermissionError:
-        # Process exists but owned by another user
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+    except psutil.AccessDenied:
+        # Exists, owned by another user — preserves the old PermissionError branch.
         return True
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,7 @@
 """Tests for services.py — PID utilities and status checks."""
 import os
+import subprocess
+import sys
 
 import pytest
 
@@ -49,8 +51,42 @@ def test_process_alive_self():
 
 def test_process_alive_dead_pid():
     # PID 2**22 is beyond the max PID on all supported platforms (Linux max=4194304=2^22,
-    # macOS max=99998). Using it guarantees ProcessLookupError without relying on timing.
+    # macOS max=99998). Using it guarantees the not-found path without relying on timing.
+    # On Windows this previously raised OSError(WinError 87) instead of returning False.
     assert _process_alive(4_200_000) is False
+
+
+def test_process_alive_exited_child_is_dead():
+    """A process that has actually exited must report dead.
+
+    This is the case the max-PID test cannot reach. On Windows a process handle
+    stays openable while any handle to it remains, so `os.kill(pid, 0)` on a
+    just-exited PID does not raise — the old implementation returned True and a
+    crashed service was reported as running. Silent, and worse than the crash.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    assert _process_alive(proc.pid) is False
+
+
+def test_process_alive_running_child_is_alive():
+    """The positive control: a child we know is running must report alive."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        assert _process_alive(proc.pid) is True
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+@pytest.mark.parametrize("pid", [0, -1, -12345])
+def test_process_alive_rejects_non_positive_pids(pid):
+    """0 and negatives are not processes.
+
+    On POSIX os.kill(0, 0) signals the caller's entire process GROUP and returns
+    cleanly, which would have reported "alive" for a PID that cannot exist.
+    """
+    assert _process_alive(pid) is False
 
 
 # ── Port check ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #149.

## What's wrong

`_process_alive()` uses `os.kill(pid, 0)`, the POSIX existence idiom. On Windows `os.kill` is implemented over `OpenProcess` rather than signals, and the function returns the wrong answer in two different ways — measured on Windows 11 / CPython 3.13:

| PID state | old behaviour | correct |
|---|---|---|
| never existed | raises `OSError(WinError 87)` — propagates out of a status check | `False` |
| **recently exited** | **returns `True`** | `False` |
| `0` / negative | returns `True` | `False` |

**The middle row is the reason this is worth fixing.** A Windows process handle stays openable while any handle to it remains, so `os.kill(pid, 0)` on a just-exited PID doesn't raise — `cce services status` reports a crashed service as healthy, with nothing to notice. The `WinError 87` crash is the loud symptom; this is the quiet one.

Non-positive PIDs slipped through too: on POSIX `os.kill(0, 0)` signals the caller's whole process group and returns cleanly, so `pid=0` reported alive.

## The change

`psutil>=5.9` is already a core dependency and already imported by `config.py`, so this uses it rather than hand-rolling a ctypes `OpenProcess` + `WaitForSingleObject` path:

```python
if pid <= 0:
    return False
try:
    return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
except psutil.NoSuchProcess:
    return False
except psutil.AccessDenied:
    return True   # exists, owned by another user — preserves the old PermissionError branch
```

Zombies are excluded deliberately: on POSIX a reaped-but-not-collected child still "exists" while not running, which is the same wrong answer in a different shape.

## Tests

Three added alongside the existing max-PID case:

- **an actually-exited child reports dead** — the case the current suite cannot reach. `test_process_alive_dead_pid` uses PID 2\*\*22, beyond the max PID on Linux/macOS, so it only exercises "never existed"; the silent wrong answer lives in the exited-process path.
- **a known-running child reports alive** — positive control, so the fix can't pass by returning `False` for everything.
- **0 and negative PIDs report dead.**

Verified by mutation rather than by watching them pass: against the previous implementation **5 tests in this file fail**; against the fix **all 23 pass**.

## CI

This also turns `tests/test_cli_smoke.py::test_services` green — it was failing for the same root cause.

One thing worth flagging separately: `ci.yml` runs the Windows job with `|| true`, so both of these failures were being swallowed rather than surfaced. That mask was hiding a real defect, not runner flakiness. Removing it is out of scope here, but you may want to once Windows is green.
