### PR TITLE
fix(status): show output compression level in cce status

### DIFF
--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1159,19 +1159,23 @@ def status(ctx: click.Context, output_json: bool, oneline: bool) -> None:
     lines.append(f"    {BULLET} {label('Compress')}      {value(compression_mode)}")
 
     # Output compression level
+    from context_engine.compression.output_rules import LEVELS as _OUT_LEVELS
     out_level = getattr(config, "output_compression", "standard")
     # state.json may override the config default (set_output_compression persists here)
-    state_path = project_storage_dir(config, _safe_cwd()) / "state.json"
+    storage = project_storage_dir(config, _safe_cwd())
+    state_path = storage / "state.json"
     if state_path.exists():
         try:
             state = json.loads(state_path.read_text(encoding="utf-8"))
             out_level = state.get("output_level", out_level)
         except (json.JSONDecodeError, OSError):
             pass
+    if out_level not in _OUT_LEVELS:
+        out_level = "standard"
     lines.append(f"    {BULLET} {label('Output')}       {value(out_level)}")
 
     # Token savings
-    stats_path = project_storage_dir(config, _safe_cwd()) / "stats.json"
+    stats_path = storage / "stats.json"
     lines.append("")
     lines.append(section("Token Savings"))
     lines.append("")

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -1158,6 +1158,18 @@ def status(ctx: click.Context, output_json: bool, oneline: bool) -> None:
     lines.append(f"    {ollama_bullet} {label('Ollama')}        {ollama_status}")
     lines.append(f"    {BULLET} {label('Compress')}      {value(compression_mode)}")
 
+    # Output compression level
+    out_level = getattr(config, "output_compression", "standard")
+    # state.json may override the config default (set_output_compression persists here)
+    state_path = project_storage_dir(config, _safe_cwd()) / "state.json"
+    if state_path.exists():
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            out_level = state.get("output_level", out_level)
+        except (json.JSONDecodeError, OSError):
+            pass
+    lines.append(f"    {BULLET} {label('Output')}       {value(out_level)}")
+
     # Token savings
     stats_path = project_storage_dir(config, _safe_cwd()) / "stats.json"
     lines.append("")


### PR DESCRIPTION
## Summary

Closes #153.

The `compression.output` config key IS wired into the MCP server (via `_apply_output_compression`, which appends the compression directive to every tool response). The reporter's claim that it's "parsed but never read" was based on testing only `cce search`, which shows raw retrieval results to a human, not AI model output.

The real gap: `cce status` didn't display the active output compression level, so users had no way to verify their setting took effect.

This PR adds an `Output` line to `cce status` showing the active level, reading from `state.json` (where `set_output_compression` persists runtime changes) with the config default as fallback.